### PR TITLE
chore: reinstate OFFLOAD_SNAPSHOT to GOE metadata

### DIFF
--- a/sql/oracle/source/sql/create_offload_repo_100.sql
+++ b/sql/oracle/source/sql/create_offload_repo_100.sql
@@ -300,6 +300,7 @@ CREATE TABLE offload_metadata (
     offload_high_value            CLOB,
     offload_predicate_type_id     INTEGER,
     offload_predicate_value       CLOB,
+    offload_snapshot              INTEGER,
     offload_hash_column           VARCHAR2(128),
     offload_sort_columns          VARCHAR2(1000),
     offload_partition_functions   VARCHAR2(1000),

--- a/sql/oracle/source/sql/create_offload_repo_package_body.sql
+++ b/sql/oracle/source/sql/create_offload_repo_package_body.sql
@@ -335,6 +335,7 @@ CREATE OR REPLACE PACKAGE BODY offload_repo AS
                    , offload_high_value
                    , offload_predicate_type_id
                    , offload_predicate_value
+                   , offload_snapshot
                    , offload_hash_column
                    , offload_sort_columns
                    , offload_partition_functions
@@ -352,6 +353,7 @@ CREATE OR REPLACE PACKAGE BODY offload_repo AS
                    , p_metadata.offload_high_value
                    , v_offload_predicate_type_id
                    , p_metadata.offload_predicate_value
+                   , p_metadata.offload_snapshot
                    , p_metadata.offload_hash_column
                    , p_metadata.offload_sort_columns
                    , p_metadata.offload_partition_functions
@@ -401,6 +403,7 @@ CREATE OR REPLACE PACKAGE BODY offload_repo AS
                     v.offload_high_value,
                     v.offload_predicate_type,
                     v.offload_predicate_value,
+                    v.offload_snapshot,
                     v.offload_hash_column,
                     v.offload_sort_columns,
                     v.offload_partition_functions,

--- a/sql/oracle/source/sql/create_offload_repo_types.sql
+++ b/sql/oracle/source/sql/create_offload_repo_types.sql
@@ -4,9 +4,9 @@
 --
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CREATE OR REPLACE TYPE offload_metadata_ot AS OBJECT
-( 
-    frontend_object_owner       VARCHAR2(128) 
-,   frontend_object_name        VARCHAR2(128) 
+(
+    frontend_object_owner       VARCHAR2(128)
+,   frontend_object_name        VARCHAR2(128)
 ,   backend_object_owner        VARCHAR2(1024)
 ,   backend_object_name         VARCHAR2(1024)
 ,   offload_type                VARCHAR2(30)
@@ -15,44 +15,12 @@ CREATE OR REPLACE TYPE offload_metadata_ot AS OBJECT
 ,   offload_high_value          CLOB
 ,   offload_predicate_type      VARCHAR2(30)
 ,   offload_predicate_value     CLOB
+,   offload_snapshot            INTEGER
 ,   offload_hash_column         VARCHAR2(128)
 ,   offload_sort_columns        VARCHAR2(1000)
 ,   offload_partition_functions VARCHAR2(1000)
 ,   command_execution           RAW(32)
-,   offload_version             VARCHAR2(30) 
-
---    hybrid_owner                VARCHAR2(128)
---,   hybrid_view                 VARCHAR2(128)
---,   hybrid_view_type            VARCHAR2(64)
---,   hybrid_external_table       VARCHAR2(128)
---,   hadoop_owner                VARCHAR2(1024)
---,   hadoop_table                VARCHAR2(1024)
---,   offload_type                VARCHAR2(30)
---,   offloaded_owner             VARCHAR2(128)
---,   offloaded_table             VARCHAR2(128)
---,   incremental_key             VARCHAR2(1000)
---,   incremental_high_value      CLOB
---,   incremental_range           VARCHAR2(20)
---,   incremental_predicate_type  VARCHAR2(30)
---,   incremental_predicate_value CLOB
---,   offload_bucket_column       VARCHAR2(128)
---,   offload_bucket_method       VARCHAR2(30)
---,   offload_bucket_count        NUMBER
---,   offload_version             VARCHAR2(30)
---,   offload_sort_columns        VARCHAR2(1000)
---,   transformations             VARCHAR2(1000)
---,   object_hash                 VARCHAR2(64)
---,   offload_scn                 NUMBER
---,   offload_partition_functions VARCHAR2(1000)
---,   iu_key_columns              VARCHAR2(1000)
---,   iu_extraction_method        VARCHAR2(30)
---,   iu_extraction_scn           NUMBER
---,   iu_extraction_time          NUMBER
---,   changelog_table             VARCHAR2(128)
---,   changelog_trigger           VARCHAR2(128)
---,   changelog_sequence          VARCHAR2(128)
---,   updatable_view              VARCHAR2(128)
---,   updatable_trigger           VARCHAR2(128)
+,   offload_version             VARCHAR2(30)
 );
 /
 SHOW ERRORS

--- a/sql/oracle/source/sql/create_offload_repo_views.sql
+++ b/sql/oracle/source/sql/create_offload_repo_views.sql
@@ -9,12 +9,13 @@ AS
     ,      fo.object_name                  AS frontend_object_name
     ,      bo.object_owner                 AS backend_object_owner
     ,      bo.object_name                  AS backend_object_name
-    ,      ot.code                         AS offload_type 
+    ,      ot.code                         AS offload_type
     ,      ort.code                        AS offload_range_type
     ,      om.offload_key                  AS offload_key
     ,      om.offload_high_value           AS offload_high_value
     ,      opt.code                        AS offload_predicate_type
-    ,      om.offload_predicate_value      AS offload_predicate_value 
+    ,      om.offload_predicate_value      AS offload_predicate_value
+    ,      om.offload_snapshot             AS offload_snapshot
     ,      om.offload_hash_column          AS offload_hash_column
     ,      om.offload_sort_columns         AS offload_sort_columns
     ,      om.offload_partition_functions  AS offload_partition_functions

--- a/src/goe/persistence/oracle/oracle_orchestration_repo_client.py
+++ b/src/goe/persistence/oracle/oracle_orchestration_repo_client.py
@@ -187,6 +187,7 @@ class OracleOrchestrationRepoClient(OrchestrationRepoClientInterface):
                     metadata_dict[INCREMENTAL_PREDICATE_VALUE]
                 )
             )
+        metadata_obj.OFFLOAD_SNAPSHOT = metadata_dict[OFFLOAD_SCN]
         metadata_obj.OFFLOAD_HASH_COLUMN = metadata_dict[OFFLOAD_BUCKET_COLUMN]
         metadata_obj.OFFLOAD_SORT_COLUMNS = metadata_dict[OFFLOAD_SORT_COLUMNS]
         metadata_obj.OFFLOAD_PARTITION_FUNCTIONS = metadata_dict[OFFLOAD_PARTITION_FUNCTIONS]
@@ -224,7 +225,7 @@ class OracleOrchestrationRepoClient(OrchestrationRepoClientInterface):
             OFFLOAD_SORT_COLUMNS: metadata_obj.OFFLOAD_SORT_COLUMNS or None,
             TRANSFORMATIONS: None,
             OBJECT_HASH: None,
-            OFFLOAD_SCN: None,
+            OFFLOAD_SCN: metadata_obj.OFFLOAD_SNAPSHOT or None,
             OFFLOAD_PARTITION_FUNCTIONS: metadata_obj.OFFLOAD_PARTITION_FUNCTIONS or None,
             IU_KEY_COLUMNS: None,
             IU_EXTRACTION_METHOD: None,


### PR DESCRIPTION
Pull request for `OFFLOAD_SNAPSHOT` column.

To test, need to reinstall GOE.

```
@uninstall_offload.sql      --NB say Y to remove GOE_REPO
@install_offload.sql
```

Remember to reset your GOE_% passwords!

The Python interface code is still mapping the new `OFFLOAD_SNAPSHOT` attribute to the existing `metadata_dict['OFFLOAD_SCN']` key (one for your refactoring).