### PR TITLE
feat: swaps from `orjson` to `msgspec`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "filelock",
     "lark-parser",
     "numpy",
-    "orjson",
+    "msgspec",
     "python-dateutil",
     "PyYAML",
     "requests",

--- a/src/goe/goe.py
+++ b/src/goe/goe.py
@@ -26,7 +26,7 @@ import re
 import traceback
 from typing import Union
 
-import orjson
+import msgspec
 
 from goe.config import orchestration_defaults
 from goe.config.config_validation_functions import normalise_size_option
@@ -295,14 +295,11 @@ def ansi(line, ansi_code):
 
 def serialize_object(obj) -> str:
     """
-    Encodes json with the optimized ORJSON package
+    Encodes json with the optimized msgspec package
 
-    orjson.dumps returns bytearray, so you can't pass it directly as json_serializer
+    Msgspec encode returns bytearray, so you can't pass it directly as json_serializer
     """
-    return orjson.dumps(
-        obj,
-        option=orjson.OPT_NAIVE_UTC | orjson.OPT_SERIALIZE_NUMPY,
-    ).decode()
+    return msgspec.json.encode(obj).decode()
 
 
 def log(line, detail=normal, ansi_code=None, redis_publish=True):

--- a/src/goe/listener/api/routes/system.py
+++ b/src/goe/listener/api/routes/system.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Third Party Libraries
-import orjson as json
+import json
 from fastapi import APIRouter, status
 
 # GOE

--- a/src/goe/listener/asgi.py
+++ b/src/goe/listener/asgi.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from cx_Oracle import DatabaseError as OracleDatabaseError
 from fastapi import FastAPI
 from fastapi.exceptions import HTTPException, RequestValidationError
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import ValidationError
 from redis.exceptions import RedisError
@@ -77,7 +77,7 @@ def get_app() -> FastAPI:
         description="GOE Listener",
         terms_of_service="https://goe.com/terms-of-service/",  # todo: update this/embed a page/add text?
         version=strict_version_ready(version()),
-        default_response_class=ORJSONResponse,
+        default_response_class=JSONResponse,
         on_startup=[events.on_startup],
         on_shutdown=[events.on_shutdown],
         logger=logger,

--- a/src/goe/listener/exceptions/base.py
+++ b/src/goe/listener/exceptions/base.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Optional, Union
 from cx_Oracle import DatabaseError as OracleDatabaseError
 from fastapi import Request, status
 from fastapi.exceptions import HTTPException, RequestValidationError
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from redis.exceptions import ConnectionError, RedisError, TimeoutError
 
@@ -121,7 +121,7 @@ async def http_error_handler(_: Request, exception: HTTPException):
             kwargs from custom HTTPException.
 
     """
-    return ORJSONResponse(
+    return JSONResponse(
         status_code=exception.status_code,
         content=exception.detail,
         headers=getattr(exception, "headers", None),
@@ -154,7 +154,7 @@ async def http422_error_handler(
 
     details = {error.get("loc")[-1]: error.get("msg") for error in exception.errors()}
     status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
-    return ORJSONResponse(
+    return JSONResponse(
         status_code=status_code,
         content=schemas.ErrorMessage(
             code=status_code, message="Validation Error", details=details
@@ -169,7 +169,7 @@ async def system_error_exception_handler(request: Request, exception: ValueError
     status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     msg = f"{exception.__class__.__name__} - {exception}"
     details = {}
-    return ORJSONResponse(
+    return JSONResponse(
         status_code=status_code,
         content=schemas.ErrorMessage(
             code=status_code, message=msg, details=details
@@ -200,7 +200,7 @@ async def app_error_handler(_: Request, exception: BaseApplicationError):
             kwargs from custom HTTPException.
 
     """
-    return ORJSONResponse(
+    return JSONResponse(
         status_code=exception.status_code,
         content=exception.content,
         headers=getattr(exception, "headers", None),
@@ -232,7 +232,7 @@ async def cache_connectivity_error(
     """
     status_code = status.HTTP_503_SERVICE_UNAVAILABLE
     message = "Failed to connect to the cache backend.  Please check your cache configuration."
-    return ORJSONResponse(
+    return JSONResponse(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         content=schemas.ErrorMessage(code=status_code, message=message).dict(
             exclude_none=True,
@@ -270,7 +270,7 @@ async def database_connectivity_error(
     else:
         message = "Failed to connect to the backend database.  Please check your database configuration."
     status_code = status.HTTP_503_SERVICE_UNAVAILABLE
-    return ORJSONResponse(
+    return JSONResponse(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         content=schemas.ErrorMessage(code=status_code, message=message).dict(
             exclude_none=True,

--- a/src/goe/listener/services/hybrid_view.py
+++ b/src/goe/listener/services/hybrid_view.py
@@ -22,7 +22,7 @@ API over orchestration code that fetches information based on a hybrid view
 import logging
 
 # Third Party Libraries
-import orjson as json
+import json
 
 # GOE
 from goe.config.orchestration_config import OrchestrationConfig

--- a/src/goe/offload/offload_messages.py
+++ b/src/goe/offload/offload_messages.py
@@ -27,7 +27,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 # Third Party Libraries
-import orjson
+import msgspec
 
 # GOE
 from goe.orchestration import orchestration_constants
@@ -85,14 +85,11 @@ logger.addHandler(logging.NullHandler())
 
 def serialize_object(obj) -> str:
     """
-    Encodes json with the optimized ORJSON package
+    Encodes json with the optimized msgspec package
 
-    orjson.dumps returns bytearray, so you can't pass it directly as json_serializer
+    Msgspec encode returns bytearray, so you can't pass it directly as json_serializer
     """
-    return orjson.dumps(
-        obj,
-        option=orjson.OPT_NAIVE_UTC | orjson.OPT_SERIALIZE_NUMPY,
-    ).decode()
+    return msgspec.json.encode(obj).decode()
 
 
 class OffloadMessages(object):

--- a/src/goe/util/json_tools.py
+++ b/src/goe/util/json_tools.py
@@ -17,29 +17,25 @@ import datetime
 from typing import Any, Union
 
 # Third Party Libraries
-import orjson
+import msgspec
 
 
-# orjson.dumps returns bytearray, so you'll can't pass it directly as json_serializer
 def serialize_object(obj) -> str:
     """
-    Encodes json with the optimized ORJSON package
+    Encodes json with the optimized msgspec package
 
-    orjson.dumps returns bytearray, so you can't pass it directly as json_serializer
+    Msgspec encode returns bytearray, so you can't pass it directly as json_serializer
     """
-    return orjson.dumps(
-        obj,
-        option=orjson.OPT_NAIVE_UTC | orjson.OPT_SERIALIZE_NUMPY,
-    ).decode()
+    return msgspec.json.encode(obj).decode()
 
 
 def deserialize_object(obj: Union[bytes, bytearray, memoryview, str]) -> Any:
     """
-    Decodes to an object with the optimized ORJSON package
+    Decodes to an object with the optimized msgspec package
 
-    orjson.dumps returns bytearray, so you can't pass it directly as json_serializer
+    msgspec decode returns bytearray, so you can't pass it directly as json_serializer
     """
-    return orjson.loads(obj)
+    return msgspec.json.decode(obj)
 
 
 def encode_datetime_object(dt: datetime.datetime) -> str:


### PR DESCRIPTION
To prepare for the update to the listener code, `orjson` should be swapped with `msgspec`.