### PR TITLE
feat: Switch GOOGLE_DATAPROC_BATCHES_SUBNET to require a full URI

### DIFF
--- a/src/goe/offload/spark/dataproc_offload_transport.py
+++ b/src/goe/offload/spark/dataproc_offload_transport.py
@@ -111,21 +111,7 @@ class OffloadTransportSparkBatchesGcloud(OffloadTransportSpark):
         if self._dataproc_batches_version:
             gcloud_cmd.append(f"--version={self._dataproc_batches_version}")
         if self._dataproc_batches_subnet:
-            if not self._dataproc_project or not self._dataproc_region:
-                raise OffloadTransportException(
-                    "GOOGLE_DATAPROC_PROJECT and GOOGLE_DATAPROC_REGION are required when using GOOGLE_DATAPROC_BATCHES_SUBNET"
-                )
-            subnet = "/".join(
-                [
-                    "projects",
-                    self._dataproc_project,
-                    "regions",
-                    self._dataproc_region,
-                    "subnetworks",
-                    self._dataproc_batches_subnet,
-                ]
-            )
-            gcloud_cmd.append(f"--subnet={subnet}")
+            gcloud_cmd.append(f"--subnet={self._dataproc_batches_subnet}")
         gcloud_cmd.append(f"--deps-bucket={self._offload_fs_container}")
         return gcloud_cmd
 

--- a/templates/conf/offload.env.template.bigquery
+++ b/templates/conf/offload.env.template.bigquery
@@ -44,18 +44,18 @@ export GOOGLE_KMS_KEY_NAME=
 
 # Google Dataproc cluster name
 export GOOGLE_DATAPROC_CLUSTER=
-# Google Dataproc/Dataproc Serverless project
+# Google Dataproc/Dataproc Batches project
 export GOOGLE_DATAPROC_PROJECT=
-# Google Dataproc/Dataproc Serverless region
+# Google Dataproc/Dataproc Batches region
 export GOOGLE_DATAPROC_REGION=
-# Google Dataproc/Dataproc Serverless service account
+# Google Dataproc/Dataproc Batches service account
 export GOOGLE_DATAPROC_SERVICE_ACCOUNT=
 # Google Dataproc Batches version, leave blank to disable Dataproc Batches
 export GOOGLE_DATAPROC_BATCHES_VERSION=
 # Google Dataproc Batches subnet
 # GOOGLE_DATAPROC_BATCHES_SUBNET defines a full subnet URI, for example:
 #   projects/my-project/regions/my-region/subnetworks/my-subnet
-# export GOOGLE_DATAPROC_BATCHES_SUBNET=
+export GOOGLE_DATAPROC_BATCHES_SUBNET=
 
 # Filesystem type for Offloaded tables
 # When offloading a table to cloud storage the table LOCATION will be structured as below:

--- a/templates/conf/offload.env.template.bigquery
+++ b/templates/conf/offload.env.template.bigquery
@@ -52,9 +52,9 @@ export GOOGLE_DATAPROC_REGION=
 export GOOGLE_DATAPROC_SERVICE_ACCOUNT=
 # Google Dataproc Batches version, leave blank to disable Dataproc Batches
 export GOOGLE_DATAPROC_BATCHES_VERSION=
-# Google Dataproc Batches subnet name
-# If set then this variable is used to form a value for Batches subnet of this form:
-# projects/${GOOGLE_DATAPROC_PROJECT}/regions/${GOOGLE_DATAPROC_REGION}/subnetworks/${GOOGLE_DATAPROC_BATCHES_SUBNET}
+# Google Dataproc Batches subnet
+# GOOGLE_DATAPROC_BATCHES_SUBNET defines a full subnet URI, for example:
+#   projects/my-project/regions/my-region/subnetworks/my-subnet
 # export GOOGLE_DATAPROC_BATCHES_SUBNET=
 
 # Filesystem type for Offloaded tables


### PR DESCRIPTION
This PR relaxes the format of the subnet we pass to `gcloud dataproc batches submit`, before this PR the code built a subnet string from three inputs as described below:

```
# If set then this variable is used to form a value for Batches subnet of this form:
# projects/${GOOGLE_DATAPROC_PROJECT}/regions/${GOOGLE_DATAPROC_REGION}/subnetworks/${GOOGLE_DATAPROC_BATCHES_SUBNET}
```
This was forcing the `GOOGLE_DATAPROC_PROJECT` setting into the subnet and there was no way to deviate from the project hosting Dataproc.

This PR removes the fixed formatting and passes the value from `offload.env` through to `gcloud` which provides extra flexibility when a shared VPC is used.