### PR TITLE
fix: Close connection used to get database version during Offload Transport

### DIFF
--- a/src/goe/offload/oracle/oracle_offload_transport_rdbms_api.py
+++ b/src/goe/offload/oracle/oracle_offload_transport_rdbms_api.py
@@ -165,6 +165,7 @@ class OffloadTransportOracleApi(OffloadTransportRdbmsApiInterface):
                 self._fixed_goe_parameters = {"CELL_OFFLOAD_PROCESSING": "FALSE"}
             else:
                 self._fixed_goe_parameters = {}
+            self._close_adm_connection()
         return self._fixed_goe_parameters
 
     def _get_fixed_sqoop_parameters(self, max_ts_scale):


### PR DESCRIPTION
We intentionally close Oracle connections during Offload transport to get around problems with idle sessions being sniped. We recently introduced a bug by moving code that checked the oracle version to later in the process of building a transport source query without including a disconnect. Due to this a second partition batch failed with ORA-3113.

If Offload transport used `OracleFrontendApi` then this would not have happened, I've created an issue for that, https://github.com/gluent/goe/issues/161, but for now we should introduce the missing disconnect. That is what this PR does.