### PR TITLE
feat: Round sampled Oracle NUMBER(17|18) up to GOE INT_38

### DIFF
--- a/src/goe/offload/oracle/oracle_offload_source_table.py
+++ b/src/goe/offload/oracle/oracle_offload_source_table.py
@@ -1444,7 +1444,7 @@ class OracleSourceTable(OffloadSourceTableInterface):
                     data_scale = 0
 
             integral_type = self._frontend_decimal_to_integral_type(
-                data_precision, data_scale
+                data_precision, data_scale, safe_mapping=column.safe_mapping
             )
             if integral_type:
                 return new_column(

--- a/tests/unit/offload/test_data_type_mappings.py
+++ b/tests/unit/offload/test_data_type_mappings.py
@@ -463,6 +463,21 @@ class TestOracleDataTypeMappings(TestDataTypeMappings):
                 data_precision=9,
                 data_scale=0,
             ),
+            # NUMBER(*) but sampled as NUMBER(n)
+            OracleColumn(
+                "COL_NUMBER_15_UNSAFE",
+                ORACLE_TYPE_NUMBER,
+                data_precision=15,
+                data_scale=0,
+                safe_mapping=False,
+            ),
+            OracleColumn(
+                "COL_NUMBER_17_UNSAFE",
+                ORACLE_TYPE_NUMBER,
+                data_precision=17,
+                data_scale=0,
+                safe_mapping=False,
+            ),
             # NUMBER(18)
             OracleColumn(
                 "COL_NUMBER_18",
@@ -578,6 +593,18 @@ class TestOracleDataTypeMappings(TestDataTypeMappings):
             CanonicalColumn("COL_NUMBER_2", GOE_TYPE_INTEGER_1),
             CanonicalColumn("COL_NUMBER_4", GOE_TYPE_INTEGER_2),
             CanonicalColumn("COL_NUMBER_9", GOE_TYPE_INTEGER_4),
+            CanonicalColumn(
+                "COL_NUMBER_15_UNSAFE",
+                GOE_TYPE_INTEGER_8,
+                data_precision=15,
+                data_scale=0,
+                safe_mapping=False,
+            ),
+            CanonicalColumn(
+                "COL_NUMBER_17_UNSAFE",
+                GOE_TYPE_INTEGER_38,
+                safe_mapping=False,
+            ),
             CanonicalColumn("COL_NUMBER_18", GOE_TYPE_INTEGER_8),
             CanonicalColumn("COL_NUMBER_38", GOE_TYPE_INTEGER_38),
             CanonicalColumn("COL_NUMBER_NO_P_S", GOE_TYPE_DECIMAL),


### PR DESCRIPTION
This PR changes the canonical column from INT8 to INT38 for **sampled** Oracle columns when the sampled precision is 17 or 18. The idea being that sampled precisions are not 100% accurate and therefore we should err on the side of caution when the sampled precision is close to the max size of integer 8.