### PR TITLE
feat: Add support log file on GCS

### DIFF
--- a/bin/offload
+++ b/bin/offload
@@ -18,24 +18,15 @@
 import sys
 
 from goe.config.config_checks import check_cli_path
+from goe.goe import (
+    get_options,
+    OFFLOAD_OP_NAME,
+)
 from goe.offload.offload import OffloadOptionError, get_offload_options
+from goe.orchestration.cli_entry_points import offload_by_cli
+
 
 check_cli_path()
-
-from goe.goe import (
-    get_log_fh_name,
-    get_options,
-    init,
-    init_log,
-    log,
-    log_command_line,
-    log_timestamp,
-    version,
-    OFFLOAD_OP_NAME,
-    get_log_fh,
-)
-from goe.orchestration.cli_entry_points import offload_by_cli
-from goe.util.goe_log import log_exception
 
 
 if __name__ == "__main__":
@@ -43,26 +34,10 @@ if __name__ == "__main__":
     try:
         opt = get_options(operation_name=OFFLOAD_OP_NAME)
         get_offload_options(opt)
-        options, args = opt.parse_args()
-        init(options)
-        init_log("offload_%s" % options.owner_table)
-
-        log("")
-        log("Offload v%s" % version(), ansi_code="underline")
-        log("Log file: %s" % get_log_fh_name())
-        log("")
-        log_command_line()
-
+        options, _ = opt.parse_args()
         offload_by_cli(options)
 
     except OffloadOptionError as exc:
-        log("Option error: %s" % exc, ansi_code="red")
-        log("")
+        print("Option error: %s\n" % exc)
         opt.print_help()
-        sys.exit(1)
-
-    except Exception as exc:
-        log("Exception caught at top-level", ansi_code="red")
-        log_timestamp()
-        log_exception(exc, log_fh=get_log_fh(), options=options)
         sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "urllib3",
 
     # For Cloud storage
+    "fsspec[gcs]",
     "google-cloud-storage",
     "boto3",
     "azure-common",

--- a/src/goe/config/config_validation_functions.py
+++ b/src/goe/config/config_validation_functions.py
@@ -59,6 +59,7 @@ from goe.offload.offload_transport import (
     VALID_OFFLOAD_TRANSPORTS,
     VALID_SPARK_SUBMIT_EXECUTABLES,
 )
+from goe.util.goe_log_fh import is_valid_path_for_logs
 from goe.util.misc_functions import human_size_to_bytes
 from goe.util.password_tools import PasswordTools
 
@@ -132,6 +133,11 @@ def normalise_db_prefix_and_paths(options, frontend_api=None):
         )
         options.load_db_name_pattern = (
             options.db_name_prefix.lower() + "_" + options.load_db_name_pattern
+        )
+
+    if not is_valid_path_for_logs(options.log_path):
+        raise OrchestrationConfigException(
+            f"Invalid value for OFFLOAD_LOGDIR: {options.log_path}"
         )
 
 

--- a/src/goe/goe.py
+++ b/src/goe/goe.py
@@ -91,7 +91,11 @@ from goe.offload.offload_source_table import (
     OFFLOAD_PARTITION_TYPE_RANGE,
     OFFLOAD_PARTITION_TYPE_LIST,
 )
-from goe.offload.offload_messages import OffloadMessages, VERBOSE, VVERBOSE
+from goe.offload.offload_messages import (
+    OffloadMessages,
+    VERBOSE,
+    VVERBOSE,
+)
 from goe.offload.offload_metadata_functions import gen_and_save_offload_metadata
 from goe.offload.offload_validation import (
     BackendCountValidator,
@@ -158,6 +162,7 @@ from goe.data_governance.hadoop_data_governance import (
     is_valid_data_governance_tag,
 )
 
+from goe.util.goe_log_fh import GOELogFileHandle
 from goe.util.misc_functions import (
     all_int_chars,
     csv_split,
@@ -358,6 +363,11 @@ def log_command_line(detail=vverbose):
     log("Command line:", detail=detail, redis_publish=False)
     log(" ".join(sys.argv), detail=detail, redis_publish=False)
     log("", detail=detail, redis_publish=False)
+
+
+def log_close():
+    global log_fh
+    log_fh.close()
 
 
 def ora_single_item_query(opts, qry, ora_conn=None, params={}):
@@ -1203,7 +1213,7 @@ def init_log(log_name):
 
     current_log_name = standard_log_name(log_name)
     log_path = os.path.join(options.log_path, current_log_name)
-    log_fh = open(log_path, "w")
+    log_fh = GOELogFileHandle(log_path)
 
     if hasattr(options, "dev_log") and options.dev_log:
         # Set tool (debug instrumentation) logging

--- a/src/goe/offload/hadoop/hadoop_backend_table.py
+++ b/src/goe/offload/hadoop/hadoop_backend_table.py
@@ -50,7 +50,7 @@ from goe.offload.offload_constants import (
     OFFLOAD_STATS_METHOD_HISTORY,
 )
 from goe.offload.offload_messages import VERBOSE, VVERBOSE
-from goe.offload.offload_transport_functions import load_db_hdfs_path, schema_paths
+from goe.offload.offload_transport_functions import load_db_hdfs_path, schema_path
 from goe.offload.backend_table import (
     BackendTableInterface,
     TYPICAL_DATE_GRANULARITY_TERMS,
@@ -163,7 +163,7 @@ class BackendHadoopTable(BackendTableInterface):
             self._hive_optimize_sort_dynamic_partition = None
 
         if self._target_owner:
-            _, self._avro_schema_hdfs_path = schema_paths(
+            self._avro_schema_hdfs_path = schema_path(
                 self._target_owner,
                 self.table_name,
                 self._load_db_name,

--- a/src/goe/offload/offload_messages.py
+++ b/src/goe/offload/offload_messages.py
@@ -32,6 +32,7 @@ import orjson
 # GOE
 from goe.orchestration import orchestration_constants
 from goe.orchestration.command_steps import STEP_TITLES, step_title
+from goe.util.goe_log_fh import GOELogFileHandle
 from goe.util.misc_functions import standard_log_name
 from goe.util.redis_tools import cache
 from goe.orchestration import command_steps
@@ -242,7 +243,7 @@ class OffloadMessages(object):
         current_log_name = standard_log_name(log_name)
         log_path = os.path.join(log_dir, current_log_name)
         logger.debug("log_path: %s" % log_path)
-        self._log_fh = open(log_path, "w")
+        self._log_fh = GOELogFileHandle(log_path)
 
     def close_log(self):
         if self._log_fh:
@@ -716,60 +717,3 @@ def step_title_to_step_id(step_title):
         return step_title.replace(" ", "_").lower()
     else:
         return None
-
-
-if __name__ == "__main__":
-    # GOE
-    from goe.util.misc_functions import set_goelib_logging
-
-    log_level = sys.argv[-1:][0].upper()
-    if log_level not in ("DEBUG", "INFO", "WARNING", "CRITICAL", "ERROR"):
-        log_level = "CRITICAL"
-
-    set_goelib_logging(log_level)
-
-    log_dir = "/tmp"
-    log_id = "goe_test_log"
-
-    print("NORMAL OffloadMessages")
-    print("=====================================")
-    messages = OffloadMessages(NORMAL)
-    messages.init_log(log_dir, log_id)
-    messages.log("A normal message")
-    messages.log("A verbose message you won't see on screen", VERBOSE)
-    messages.log("Nor this", VVERBOSE)
-    messages.log("More normality")
-    messages.step_delta("Normal Stuff", timedelta(0, 160, 615919))
-    messages.log("Honk honk", ansi_code="red")
-    messages.step_delta("Bad Stuff", timedelta(0, 130, 651717))
-    messages.warning("Honk honk", ansi_code="red")
-    messages.step_delta("Bad Stuff", timedelta(0, 9101, 651717))
-    messages.log_step_deltas()
-    messages.close_log()
-    print("=====================================")
-
-    print("As above but QUIET")
-    print("=====================================")
-    messages = OffloadMessages(QUIET)
-    messages.init_log(log_dir, log_id)
-    messages.log("A normal message")
-    messages.log("A verbose message you won't see on screen", VERBOSE)
-    messages.log("Nor this", VVERBOSE)
-    messages.log("More normality")
-    messages.log("Honk honk", ansi_code="red")
-    messages.warning("Honk honk", ansi_code="red")
-    messages.close_log()
-    print("=====================================")
-
-    print("VERBOSE OffloadMessages")
-    print("=====================================")
-    messages = OffloadMessages(VERBOSE)
-    messages.init_log(log_dir, log_id)
-    messages.log("A normal message")
-    messages.log("A verbose message you will see", VERBOSE)
-    messages.log("But not this", VVERBOSE)
-    messages.log("More normality")
-    messages.log("Honk honk", ansi_code="red")
-    messages.warning("Honk honk", ansi_code="red")
-    messages.close_log()
-    print("=====================================")

--- a/src/goe/offload/offload_transport.py
+++ b/src/goe/offload/offload_transport.py
@@ -65,7 +65,7 @@ from goe.offload.offload_transport_functions import (
     running_as_same_user_and_host,
     scp_to_cmd,
     ssh_cmd_prefix,
-    schema_paths,
+    get_local_staging_path,
 )
 from goe.offload.offload_transport_rdbms_api import (
     TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_ID_RANGE,
@@ -2755,18 +2755,19 @@ class OffloadTransportQueryImport(OffloadTransport):
         # Not applicable to Query Import
         return None
 
-    def _query_import_to_local_fs(self, partition_chunk=None):
-        """Query Import is not partition aware therefore partition_chunk is ignored"""
+    def _query_import_to_local_fs(self, partition_chunk=None) -> tuple:
+        """Execute Query Import transport.
+
+        Query Import is not partition aware therefore partition_chunk is ignored"""
 
         if self._nothing_to_do(partition_chunk):
             return 0
 
-        local_staging_path, _ = schema_paths(
+        local_staging_path = get_local_staging_path(
             self._target_owner,
             self._target_table_name,
-            self._load_db_name,
             self._offload_options,
-            local_extension_override="." + self._staging_format.lower(),
+            "." + self._staging_format.lower(),
         )
         dfs_load_path = os.path.join(
             self._staging_table_location, "part-m-00000." + self._staging_format.lower()

--- a/src/goe/offload/offload_transport_functions.py
+++ b/src/goe/offload/offload_transport_functions.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python3
-
 # Copyright 2016 The GOE Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +20,6 @@ import logging
 from getpass import getuser
 import math
 import os
-from re import sub
 from socket import gethostname, getfqdn
 import subprocess
 from subprocess import PIPE, STDOUT
@@ -78,25 +75,23 @@ logger.addHandler(logging.NullHandler())
 ###########################################################################
 
 
-def offload_transport_file_name(name_prefix, extension=""):
+def offload_transport_file_name(name_prefix, extension="") -> str:
     return standard_file_name(name_prefix, extension=extension)
 
 
-def load_db_hdfs_path(load_db_name, offload_options):
+def load_db_hdfs_path(load_db_name: str, config: "OrchestrationConfig") -> str:
     assert load_db_name
-    assert offload_options.hdfs_load
-    return os.path.join(
-        offload_options.hdfs_load, load_db_name + offload_options.hdfs_db_path_suffix
-    )
+    assert config.hdfs_load
+    return os.path.join(config.hdfs_load, load_db_name + config.hdfs_db_path_suffix)
 
 
-def avsc_hdfs_path(load_db_name, schema_filename, offload_options):
-    if offload_options.backend_distribution not in HADOOP_BASED_BACKEND_DISTRIBUTIONS:
+def avsc_hdfs_path(
+    load_db_name: str, schema_filename: str, config: "OrchestrationConfig"
+) -> str:
+    if config.backend_distribution not in HADOOP_BASED_BACKEND_DISTRIBUTIONS:
         # No HDFS in play
         return None
-    return os.path.join(
-        load_db_hdfs_path(load_db_name, offload_options), schema_filename
-    )
+    return os.path.join(load_db_hdfs_path(load_db_name, config), schema_filename)
 
 
 def get_local_staging_path(
@@ -129,7 +124,7 @@ def schema_path(
     return avsc_hdfs_path(load_db_name, schema_filename, config)
 
 
-def ssh_cmd_prefix(ssh_user, host):
+def ssh_cmd_prefix(ssh_user, host) -> list:
     assert ssh_user
     assert host
     if ssh_user == getuser() and host == "localhost":
@@ -137,7 +132,7 @@ def ssh_cmd_prefix(ssh_user, host):
     return ["ssh", "-tq", ssh_user + "@" + host]
 
 
-def scp_to_cmd(user, host, from_path, to_path):
+def scp_to_cmd(user, host, from_path, to_path) -> list:
     if user == getuser() and host == "localhost":
         if to_path[0] != "/":
             to_path = os.path.join(os.environ.get("HOME"), to_path)
@@ -166,7 +161,7 @@ def get_rdbms_connection_for_oracle(
     return ora_conn
 
 
-def credential_provider_path_jvm_override(credential_provider_path):
+def credential_provider_path_jvm_override(credential_provider_path) -> str:
     """return a JVM override clause to point to credential provider file"""
     if not credential_provider_path:
         return ""

--- a/src/goe/orchestration/orchestration_runner.py
+++ b/src/goe/orchestration/orchestration_runner.py
@@ -492,6 +492,9 @@ class OrchestrationRunner:
             self._command_fail(command_id, exc, repo_client)
             repo_client.close(force=True)
             raise
+        finally:
+            if not reuse_log:
+                self._messages.close_log()
 
         return status
 

--- a/src/goe/scripts/agg_validate.py
+++ b/src/goe/scripts/agg_validate.py
@@ -41,9 +41,10 @@ from goe.util.misc_functions import (
     parse_python_from_string,
     check_offload_env,
 )
-from goe.util.goe_log import step, log_exception
+from goe.util.goe_log import log_exception
 
 from goe.offload.offload_messages import OffloadMessages
+from goe.orchestration import command_steps
 
 from goe.goe import (
     get_options_from_list,
@@ -132,12 +133,10 @@ def validate_table(args, messages):
             return False
 
     return (
-        step(
-            "Validating table: %s.%s" % (args.owner, args.table_name),
+        messages.offload_step(
+            command_steps.STEP_VALIDATE_DATA,
             step_fn,
             execute=args.execute,
-            options=args,
-            messages=messages,
         )
         or False
     )

--- a/src/goe/util/goe_log.py
+++ b/src/goe/util/goe_log.py
@@ -20,15 +20,12 @@
     and do not rely on 'expected' parameter structure
 """
 
-import copy
+from argparse import Namespace
+from datetime import datetime
 import logging
-import os
-import os.path
 import sys
 import traceback
 
-from argparse import Namespace
-from datetime import datetime
 
 from goe.offload.offload_messages import (
     OffloadMessages,
@@ -128,39 +125,6 @@ def log_exception(exception, detail=NORMAL, log_fh=None, options=get_default_opt
         sys.stdout.flush()
 
 
-def init_default_log(log_name, options=get_default_options()):
-    assert log_name
-    global global_log_fh
-
-    if global_log_fh:
-        logger.warn(
-            "Initializing log: %s while previous log: %s is active"
-            % (log_name, global_log_fh.name)
-        )
-
-    options.log_path = get_option(options, "log_path", None) or os.environ.get(
-        "OFFLOAD_LOGDIR"
-    )
-    if not options.log_path and os.environ.get("OFFLOAD_HOME"):
-        options.log_path = os.path.join(os.environ.get("OFFLOAD_HOME"), "log")
-
-    options.log_path = options.log_path or "."
-
-    current_log_name = "%s_%s.log" % (log_name, datetime.now().isoformat())
-    log_path = os.path.join(options.log_path, current_log_name)
-
-    logger.debug("Initializing default text on-disk log file as: %s" % log_path)
-    global_log_fh = open(log_path, "w")
-
-
-def close_default_log():
-    if global_log_fh:
-        logger.debug(
-            "Closing default text on-disk log file as: %s" % global_log_fh.name
-        )
-        global_log_fh.close()
-
-
 def ansi(line, ansi_code, options=get_default_options()):
     return OffloadMessages.ansi_wrap(line, ansi_code, get_option(options, "ansi"))
 
@@ -186,162 +150,3 @@ def log_timedelta(start_time, ansi_code="grey", options=get_default_options()):
             options=options,
         )
         return ts2 - start_time
-
-
-def step(
-    title,
-    step_fn,
-    execute=False,
-    skip=None,
-    messages=None,
-    optional=False,
-    options=get_default_options(),
-):
-    step_results = None
-
-    # Do not pollute original 'options' object which is passed (upwards) by reference
-    step_options = copy.copy(options)
-    set_option(step_options, "execute", execute)
-
-    log("", options=step_options)
-    log(title, ansi_code="underline", options=step_options)
-    start_time = log_timestamp(options=step_options)
-
-    step_id = title.replace(" ", "_").lower()
-    if skip and step_id in skip:
-        log("skipped", options=step_options)
-    else:
-        try:
-            if execute:
-                step_results = step_fn()
-                td = log_timedelta(start_time, options=step_options)
-                log("Done", ansi_code="green", options=step_options)
-                if messages:
-                    messages.step_delta(title, td)
-            else:
-                step_results = True
-        except Exception as exc:
-            log_timedelta(start_time, options=step_options)
-            if optional:
-                if messages:
-                    messages.warning(
-                        'Error in "%s": %s' % (title, str(exc)), ansi_code="red"
-                    )
-                else:
-                    log(str(exc), ansi_code="red", options=step_options)
-                log(
-                    "Optional step, continuing", ansi_code="green", options=step_options
-                )
-            else:
-                raise
-
-    return step_results
-
-
-if __name__ == "__main__":
-    import time
-
-    from functools import partial
-
-    from goe.util.goe_log import (
-        log as log_f,
-        step as step_f,
-        init_default_log,
-        get_default_log,
-        close_default_log,
-    )
-
-    def main():
-        def waiter3():
-            time.sleep(3)
-
-        def waiter2():
-            time.sleep(2)
-
-        messages = OffloadMessages(VERBOSE)
-
-        print("== DEFAULT AND NORMAL")
-        log_f("Hello, maties, I'm colorless !")
-        log_f("Hello, maties in red!", ansi_code="red")
-        log_f("Hello, maties in green!", ansi_code="green")
-        log_f(
-            "Hello, maties - I'm VERBOSE (you should see me)!",
-            detail=VERBOSE,
-            ansi_code="green",
-        )
-        log_f(
-            "Hello, maties - I'm VVERBOSE (you should NOT see me)!",
-            detail=VVERBOSE,
-            ansi_code="green",
-        )
-        step_f(
-            "Waiting for 3 seconds and executing",
-            waiter3,
-            messages=messages,
-            execute=True,
-        )
-        step_f("Waiting for 2 seconds and NOT executing", waiter2, messages=messages)
-        print("== END DEFAULT")
-
-        options = get_default_options({"ansi": True, "verbose": True})
-        log = partial(log_f, options=options)
-        step = partial(step_f, options=options)
-
-        print("\n\n== CUSTOM OPTIONS AND VERBOSE")
-        log("Hello, maties, I'm colorless !")
-        log("Hello, maties in red!", ansi_code="red")
-        log("Hello, maties in green!", ansi_code="green")
-        log(
-            "Hello, maties - I'm VERBOSE (you should see me)!",
-            detail=VERBOSE,
-            ansi_code="green",
-        )
-        log(
-            "Hello, maties - I'm VVERBOSE (you should NOT see me)!",
-            detail=VVERBOSE,
-            ansi_code="green",
-        )
-        step(
-            "Waiting for 3 seconds and executing",
-            waiter3,
-            messages=messages,
-            execute=True,
-        )
-        step("Waiting for 2 seconds and NOT executing", waiter2, messages=messages)
-        print("== END CUSTOM OPTIONS")
-
-        options.log_path = "/tmp"
-        init_default_log("goe_log", options)
-
-        print("\n\n== DUP TO LOG FILE")
-        log("Hello, maties, I'm colorless !")
-        log("Hello, maties in red!", ansi_code="red")
-        log("Hello, maties in green!", ansi_code="green")
-        log(
-            "Hello, maties - I'm VERBOSE (you should see me)!",
-            detail=VERBOSE,
-            ansi_code="green",
-        )
-        log(
-            "Hello, maties - I'm VVERBOSE (you should NOT see me)!",
-            detail=VVERBOSE,
-            ansi_code="green",
-        )
-        step(
-            "Waiting for 3 seconds and executing",
-            waiter3,
-            messages=messages,
-            execute=True,
-        )
-        step("Waiting for 2 seconds and NOT executing", waiter2, messages=messages)
-
-        log_name = get_default_log().name
-        close_default_log()
-
-        print("-- Log lines from file: %s" % log_name)
-        with open(log_name) as fh:
-            for line in fh:
-                print(line)
-        print("== END DUP TO LOG FILE")
-
-    main()

--- a/src/goe/util/goe_log_fh.py
+++ b/src/goe/util/goe_log_fh.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import fsspec
+from gcsfs.core import GCS_MIN_BLOCK_SIZE
 
 
 def is_gcs_path(path: str):
@@ -26,10 +27,10 @@ def is_valid_path_for_logs(path: str):
 class GOELogFileHandle:
     name: str = None
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, mode="w"):
         self._fs = self._get_fs(path)
         self.name = path
-        self._fh = self._open(path)
+        self._fh = self._open(path, mode=mode)
 
     def __enter__(self):
         return self._fh
@@ -45,7 +46,7 @@ class GOELogFileHandle:
             if it cannot authenticate with GCS.
             https://gcsfs.readthedocs.io/en/latest/api.html#gcsfs.core.GCSFileSystem
             """
-            fs = fsspec.filesystem("gs")
+            fs = fsspec.filesystem("gs", block_size=GCS_MIN_BLOCK_SIZE)
         else:
             fs = fsspec.filesystem("file")
         return fs

--- a/src/goe/util/goe_log_fh.py
+++ b/src/goe/util/goe_log_fh.py
@@ -15,8 +15,12 @@
 import fsspec
 
 
+def is_gcs_path(path: str):
+    return bool(path and path.startswith("gs://"))
+
+
 def is_valid_path_for_logs(path: str):
-    return bool(path and (path.startswith("/") or path.startswith("gs://")))
+    return bool(path and (path.startswith("/") or is_gcs_path(path)))
 
 
 class GOELogFileHandle:

--- a/src/goe/util/goe_log_fh.py
+++ b/src/goe/util/goe_log_fh.py
@@ -1,0 +1,58 @@
+# Copyright 2024 The GOE Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import fsspec
+
+
+class GOELogFileHandle:
+    name: str = None
+
+    def __init__(self, path: str):
+        self._fs = self._get_fs(path)
+        self.name = path
+        self._fh = self._open(path)
+
+    def __enter__(self):
+        return self._fh
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def _get_fs(self, path: str) -> fsspec.AbstractFileSystem:
+        """Determine filesystem type of a path."""
+        if path.startswith("gs://"):
+            """Do not pass in the token so that gcsfs will try and get the application
+            default credentials from a number of sources. This will raise an exception
+            if it cannot authenticate with GCS.
+            https://gcsfs.readthedocs.io/en/latest/api.html#gcsfs.core.GCSFileSystem
+            """
+            fs = fsspec.filesystem("gs")
+        else:
+            fs = fsspec.filesystem("file")
+        return fs
+
+    def _open(self, path: str, mode="w"):
+        return self._fs.open(path, mode=mode)
+
+    def close(self):
+        if not self._fh.closed:
+            return self._fh.close()
+
+    def flush(self):
+        # On GCSFileSystem _fh.flush() doesn't actually flush unless the buffer is beyond block size.
+        # Plus we can't set the block size artifically low. In practice
+        self._fh.flush()
+
+    def write(self, *args, **kwargs):
+        return self._fh.write(*args, **kwargs)

--- a/src/goe/util/goe_log_fh.py
+++ b/src/goe/util/goe_log_fh.py
@@ -15,6 +15,10 @@
 import fsspec
 
 
+def is_valid_path_for_logs(path: str):
+    return bool(path and (path.startswith("/") or path.startswith("gs://")))
+
+
 class GOELogFileHandle:
     name: str = None
 
@@ -30,7 +34,7 @@ class GOELogFileHandle:
         self.close()
 
     def _get_fs(self, path: str) -> fsspec.AbstractFileSystem:
-        """Determine filesystem type of a path."""
+        """Get fsspec filesystem for path."""
         if path.startswith("gs://"):
             """Do not pass in the token so that gcsfs will try and get the application
             default credentials from a number of sources. This will raise an exception

--- a/templates/conf/offload.env.template.common
+++ b/templates/conf/offload.env.template.common
@@ -119,6 +119,7 @@ export PATH=${OFFLOAD_HOME}/bin:$PATH:$KERBEROS_PATH
 export OFFLOAD_CONFDIR=${OFFLOAD_HOME}/conf
 
 # Override log path, defaults to OFFLOAD_HOME/log
+# Also supports Google Cloud Storage paths, e.g.: gs://my-bucket/my-prefix
 #export OFFLOAD_LOGDIR=
 
 # Default number of external table location files for parallel data retrieval

--- a/tests/integration/scenarios/scenario_runner.py
+++ b/tests/integration/scenarios/scenario_runner.py
@@ -92,7 +92,9 @@ def run_offload(
             )
         if expected_exception_string:
             # We shouldn't get here if we're expecting an exception
-            messages.log("Missing exception containing: %s" % expected_exception_string)
+            parent_messages.log(
+                "Missing exception containing: %s" % expected_exception_string
+            )
             # Can't include exception in error below otherwise we'll end up with a pass
             raise ScenarioRunnerException("offload() did not throw expected exception")
     except Exception as exc:
@@ -100,14 +102,14 @@ def run_offload(
             expected_exception_string
             and expected_exception_string.lower() in str(exc).lower()
         ):
-            messages.log(
+            parent_messages.log(
                 "Test caught expected exception:%s\n%s" % (type(exc), str(exc))
             )
-            messages.log(
+            parent_messages.log(
                 "Ignoring exception containing: %s" % expected_exception_string
             )
         else:
-            messages.log(traceback.format_exc())
+            parent_messages.log(traceback.format_exc())
             raise
     return messages
 

--- a/tests/integration/scenarios/scenario_runner.py
+++ b/tests/integration/scenarios/scenario_runner.py
@@ -68,6 +68,7 @@ def run_offload(
     expected_status=True,
     expected_exception_string: str = None,
     config_overrides: dict = None,
+    no_messages_override: bool = False,
 ) -> OffloadMessages:
     execution_id = ExecutionId()
     messages = OffloadMessages.from_options(
@@ -78,11 +79,12 @@ def run_offload(
     )
     try:
         config_overrides = get_config_overrides(config_overrides, orchestration_config)
+        messages_override = None if no_messages_override else messages
         status = OrchestrationRunner(config_overrides=config_overrides).offload(
             option_dict,
             execution_id=execution_id,
-            reuse_log=True,
-            messages_override=messages,
+            reuse_log=(not no_messages_override),
+            messages_override=messages_override,
         )
         if expected_status is not None and status != expected_status:
             raise ScenarioRunnerException(

--- a/tests/integration/scenarios/test_cli_api.py
+++ b/tests/integration/scenarios/test_cli_api.py
@@ -71,18 +71,6 @@ def get_bin_path():
     return os.path.join(offload_home, "bin")
 
 
-def get_log_path():
-    offload_home = os.environ.get("OFFLOAD_HOME")
-    assert offload_home, "OFFLOAD_HOME must be set in order to run tests"
-    return os.path.join(offload_home, "log")
-
-
-def get_run_path():
-    offload_home = os.environ.get("OFFLOAD_HOME")
-    assert offload_home, "OFFLOAD_HOME must be set in order to run tests"
-    return os.path.join(offload_home, "run")
-
-
 def command_supports_no_version_check(list_of_args):
     return bool(
         list_of_args[0].endswith("connect") or list_of_args[0].endswith("offload")

--- a/tests/integration/scenarios/test_cli_api.py
+++ b/tests/integration/scenarios/test_cli_api.py
@@ -39,8 +39,8 @@ from tests.integration.test_functions import (
 from tests.testlib.test_framework import test_constants
 from tests.testlib.test_framework.test_functions import (
     get_backend_testing_api,
-    get_frontend_testing_api,
-    get_test_messages,
+    get_frontend_testing_api_ctx,
+    get_test_messages_ctx,
 )
 
 
@@ -90,187 +90,193 @@ def goe_shell_command(list_of_args):
 
 def test_cli_connect(config):
     id = "test_cli_connect"
-    messages = get_test_messages(config, id)
-    bin_path = get_bin_path()
+    with get_test_messages_ctx(config, id) as messages:
+        bin_path = get_bin_path()
 
-    run_shell_cmd(
-        config, messages, goe_shell_command([os.path.join(bin_path, "connect"), "-h"])
-    )
+        run_shell_cmd(
+            config,
+            messages,
+            goe_shell_command([os.path.join(bin_path, "connect"), "-h"]),
+        )
 
-    run_shell_cmd(
-        config, messages, goe_shell_command([os.path.join(bin_path, "connect")])
-    )
+        run_shell_cmd(
+            config, messages, goe_shell_command([os.path.join(bin_path, "connect")])
+        )
 
 
 def test_cli_offload_opts(config):
     id = "test_cli_offload_opts"
-    messages = get_test_messages(config, id)
-    bin_path = get_bin_path()
+    with get_test_messages_ctx(config, id) as messages:
+        bin_path = get_bin_path()
 
-    run_shell_cmd(
-        config, messages, goe_shell_command([os.path.join(bin_path, "offload"), "-h"])
-    )
+        run_shell_cmd(
+            config,
+            messages,
+            goe_shell_command([os.path.join(bin_path, "offload"), "-h"]),
+        )
 
-    run_shell_cmd(
-        config,
-        messages,
-        goe_shell_command([os.path.join(bin_path, "offload"), "--version"]),
-    )
+        run_shell_cmd(
+            config,
+            messages,
+            goe_shell_command([os.path.join(bin_path, "offload"), "--version"]),
+        )
 
 
 def test_cli_offload_full(config, schema, data_db):
     id = "test_cli_offload_full"
-    messages = get_test_messages(config, id)
-    backend_api = get_backend_testing_api(config, messages)
-    frontend_api = get_frontend_testing_api(config, messages)
-    bin_path = get_bin_path()
+    with get_test_messages_ctx(config, id) as messages, get_frontend_testing_api_ctx(
+        config, messages, trace_action=id
+    ) as frontend_api:
+        backend_api = get_backend_testing_api(config, messages)
+        bin_path = get_bin_path()
 
-    # Setup
-    run_setup(
-        frontend_api,
-        backend_api,
-        config,
-        messages,
-        frontend_sqls=frontend_api.standard_dimension_frontend_ddl(schema, CLI_DIM),
-        python_fns=lambda: drop_backend_test_table(
+        # Setup
+        run_setup(
+            frontend_api,
+            backend_api,
+            config,
+            messages,
+            frontend_sqls=frontend_api.standard_dimension_frontend_ddl(schema, CLI_DIM),
+            python_fns=lambda: drop_backend_test_table(
+                config, backend_api, messages, data_db, CLI_DIM
+            ),
+        )
+
+        assert not backend_table_exists(config, backend_api, messages, data_db, CLI_DIM)
+
+        # Non-execute mode
+        run_shell_cmd(
+            config,
+            messages,
+            goe_shell_command(
+                [
+                    os.path.join(bin_path, "offload"),
+                    "-t",
+                    schema + "." + CLI_DIM,
+                    "--reset-backend-table",
+                ]
+            ),
+        )
+
+        assert not backend_table_exists(
             config, backend_api, messages, data_db, CLI_DIM
-        ),
-    )
+        ), "The backend table should NOT exist"
 
-    assert not backend_table_exists(config, backend_api, messages, data_db, CLI_DIM)
+        # Execute mode
+        run_shell_cmd(
+            config,
+            messages,
+            goe_shell_command(
+                [
+                    os.path.join(bin_path, "offload"),
+                    "-t",
+                    schema + "." + CLI_DIM,
+                    "-x",
+                    "--reset-backend-table",
+                    "--create-backend-db",
+                ]
+            ),
+        )
 
-    # Non-execute mode
-    run_shell_cmd(
-        config,
-        messages,
-        goe_shell_command(
-            [
-                os.path.join(bin_path, "offload"),
-                "-t",
-                schema + "." + CLI_DIM,
-                "--reset-backend-table",
-            ]
-        ),
-    )
+        assert backend_table_exists(
+            config, backend_api, messages, data_db, CLI_DIM
+        ), "The backend table should exist"
 
-    assert not backend_table_exists(
-        config, backend_api, messages, data_db, CLI_DIM
-    ), "The backend table should NOT exist"
+        # Execute mode with many options
+        run_shell_cmd(
+            config,
+            messages,
+            goe_shell_command(
+                [
+                    os.path.join(bin_path, "offload"),
+                    "-t",
+                    schema + "." + CLI_DIM,
+                    "-x",
+                    "--force",
+                    "--reset-backend-table",
+                    "--reset-backend-table",
+                    "--skip-steps=xyz",
+                    "--allow-decimal-scale-rounding",
+                    "--allow-floating-point-conversions",
+                    "--allow-nanosecond-timestamp-columns",
+                    "--compress-load-table",
+                    "--data-sample-parallelism=2",
+                    "--max-offload-chunk-count=4",
+                    "--offload-fs-scheme={}".format(
+                        orchestration_defaults.offload_fs_scheme_default()
+                    ),
+                    "--no-verify",
+                ]
+            ),
+        )
 
-    # Execute mode
-    run_shell_cmd(
-        config,
-        messages,
-        goe_shell_command(
-            [
-                os.path.join(bin_path, "offload"),
-                "-t",
-                schema + "." + CLI_DIM,
-                "-x",
-                "--reset-backend-table",
-                "--create-backend-db",
-            ]
-        ),
-    )
-
-    assert backend_table_exists(
-        config, backend_api, messages, data_db, CLI_DIM
-    ), "The backend table should exist"
-
-    # Execute mode with many options
-    run_shell_cmd(
-        config,
-        messages,
-        goe_shell_command(
-            [
-                os.path.join(bin_path, "offload"),
-                "-t",
-                schema + "." + CLI_DIM,
-                "-x",
-                "--force",
-                "--reset-backend-table",
-                "--reset-backend-table",
-                "--skip-steps=xyz",
-                "--allow-decimal-scale-rounding",
-                "--allow-floating-point-conversions",
-                "--allow-nanosecond-timestamp-columns",
-                "--compress-load-table",
-                "--data-sample-parallelism=2",
-                "--max-offload-chunk-count=4",
-                "--offload-fs-scheme={}".format(
-                    orchestration_defaults.offload_fs_scheme_default()
-                ),
-                "--no-verify",
-            ]
-        ),
-    )
-
-    assert backend_table_exists(
-        config, backend_api, messages, data_db, CLI_DIM
-    ), "The backend table should exist"
+        assert backend_table_exists(
+            config, backend_api, messages, data_db, CLI_DIM
+        ), "The backend table should exist"
 
 
 def test_cli_offload_rpa(config, schema, data_db):
     id = "test_cli_offload_rpa"
-    messages = get_test_messages(config, id)
-    backend_api = get_backend_testing_api(config, messages)
-    frontend_api = get_frontend_testing_api(config, messages)
-    bin_path = get_bin_path()
+    with get_test_messages_ctx(config, id) as messages, get_frontend_testing_api_ctx(
+        config, messages, trace_action=id
+    ) as frontend_api:
+        backend_api = get_backend_testing_api(config, messages)
+        bin_path = get_bin_path()
 
-    # Setup
-    run_setup(
-        frontend_api,
-        backend_api,
-        config,
-        messages,
-        frontend_sqls=frontend_api.sales_based_fact_create_ddl(
-            schema, CLI_FACT, simple_partition_names=True
-        ),
-        python_fns=lambda: drop_backend_test_table(
+        # Setup
+        run_setup(
+            frontend_api,
+            backend_api,
+            config,
+            messages,
+            frontend_sqls=frontend_api.sales_based_fact_create_ddl(
+                schema, CLI_FACT, simple_partition_names=True
+            ),
+            python_fns=lambda: drop_backend_test_table(
+                config, backend_api, messages, data_db, CLI_FACT
+            ),
+        )
+
+        assert not backend_table_exists(
             config, backend_api, messages, data_db, CLI_FACT
-        ),
-    )
+        ), "The backend table should NOT exist"
 
-    assert not backend_table_exists(
-        config, backend_api, messages, data_db, CLI_FACT
-    ), "The backend table should NOT exist"
+        run_shell_cmd(
+            config,
+            messages,
+            goe_shell_command(
+                [
+                    os.path.join(bin_path, "offload"),
+                    "-t",
+                    schema + "." + CLI_FACT,
+                    "-x",
+                    f"--older-than-date={test_constants.SALES_BASED_FACT_HV_2}",
+                    "--reset-backend-table",
+                    "--create-backend-db",
+                ]
+            ),
+        )
 
-    run_shell_cmd(
-        config,
-        messages,
-        goe_shell_command(
-            [
-                os.path.join(bin_path, "offload"),
-                "-t",
-                schema + "." + CLI_FACT,
-                "-x",
-                f"--older-than-date={test_constants.SALES_BASED_FACT_HV_2}",
-                "--reset-backend-table",
-                "--create-backend-db",
-            ]
-        ),
-    )
+        assert backend_table_exists(
+            config, backend_api, messages, data_db, CLI_FACT
+        ), "The backend table should exist"
 
-    assert backend_table_exists(
-        config, backend_api, messages, data_db, CLI_FACT
-    ), "The backend table should exist"
+        run_shell_cmd(
+            config,
+            messages,
+            goe_shell_command(
+                [
+                    os.path.join(bin_path, "offload"),
+                    "-t",
+                    schema + "." + CLI_FACT,
+                    "-x",
+                    "-v",
+                    f"--older-than-date={test_constants.SALES_BASED_FACT_HV_3}",
+                    "--reset-backend-table",
+                ]
+            ),
+        )
 
-    run_shell_cmd(
-        config,
-        messages,
-        goe_shell_command(
-            [
-                os.path.join(bin_path, "offload"),
-                "-t",
-                schema + "." + CLI_FACT,
-                "-x",
-                "-v",
-                f"--older-than-date={test_constants.SALES_BASED_FACT_HV_3}",
-                "--reset-backend-table",
-            ]
-        ),
-    )
-
-    assert backend_table_exists(
-        config, backend_api, messages, data_db, CLI_FACT
-    ), "The backend table should exist"
+        assert backend_table_exists(
+            config, backend_api, messages, data_db, CLI_FACT
+        ), "The backend table should exist"

--- a/tests/integration/scenarios/test_offload_basic.py
+++ b/tests/integration/scenarios/test_offload_basic.py
@@ -64,7 +64,9 @@ from tests.testlib.test_framework import test_constants
 from tests.testlib.test_framework.test_functions import (
     get_backend_testing_api,
     get_frontend_testing_api,
+    get_frontend_testing_api_ctx,
     get_test_messages,
+    get_test_messages_ctx,
 )
 
 
@@ -374,7 +376,6 @@ def test_offload_basic_dim(config, schema, data_db):
         config, backend_api, messages, repo_client, schema, data_db, OFFLOAD_DIM
     )
     assert offload_basic_dim_assertion(backend_api, messages, data_db, backend_name)
-
     # Connections are being left open, explicitly close them.
     frontend_api.close()
 
@@ -617,68 +618,67 @@ def test_offload_basic_fact(config, schema, data_db):
         OFFLOAD_FACT,
         test_constants.SALES_BASED_FACT_HV_4,
     )
-
     # Connections are being left open, explicitly close them.
     frontend_api.close()
 
 
 def test_offload_log_path_gcs(config, schema, data_db):
     id = "test_offload_log_path_gcs"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages, get_frontend_testing_api_ctx(
+        config, messages, trace_action=id
+    ) as frontend_api:
+        if (
+            config.offload_fs_scheme != OFFLOAD_FS_SCHEME_GS
+            or config.log_path.startswith("gs:")
+        ):
+            messages.log(f"Skipping {id} because it is unnecessary for current config")
+            pytest.skip(f"Skipping {id} because it is unnecessary for current config")
 
-    if config.offload_fs_scheme != OFFLOAD_FS_SCHEME_GS or config.log_path.startswith(
-        "gs:"
-    ):
-        messages.log(f"Skipping {id} because it is unnecessary for current config")
-        pytest.skip(f"Skipping {id} because it is unnecessary for current config")
+        backend_api = get_backend_testing_api(config, messages)
+        repo_client = orchestration_repo_client_factory(
+            config, messages, trace_action=f"repo_client({id})"
+        )
+        table_name = GCS_LOG_DIM
 
-    backend_api = get_backend_testing_api(config, messages)
-    frontend_api = get_frontend_testing_api(config, messages, trace_action=id)
-    repo_client = orchestration_repo_client_factory(
-        config, messages, trace_action=f"repo_client({id})"
-    )
-    table_name = GCS_LOG_DIM
-
-    # Setup
-    run_setup(
-        frontend_api,
-        backend_api,
-        config,
-        messages,
-        frontend_sqls=frontend_api.standard_dimension_frontend_ddl(schema, table_name),
-        python_fns=[
-            lambda: drop_backend_test_table(
-                config, backend_api, messages, data_db, table_name
+        # Setup
+        run_setup(
+            frontend_api,
+            backend_api,
+            config,
+            messages,
+            frontend_sqls=frontend_api.standard_dimension_frontend_ddl(
+                schema, table_name
             ),
-        ],
-    )
+            python_fns=[
+                lambda: drop_backend_test_table(
+                    config, backend_api, messages, data_db, table_name
+                ),
+            ],
+        )
 
-    # Our config is GCS capable and we are not logging to GCS.
-    # So let's override the log path with one putting the logs in GCS.
-    log_path = gen_fs_uri(
-        os.path.join(config.offload_fs_prefix, "test_logs"),
-        scheme=config.offload_fs_scheme,
-        container=config.offload_fs_container,
-    )
-    messages.log(f"Logging Offload to log_path: {log_path}")
+        # Our config is GCS capable and we are not logging to GCS.
+        # So let's override the log path with one putting the logs in GCS.
+        log_path = gen_fs_uri(
+            os.path.join(config.offload_fs_prefix, "test_logs"),
+            scheme=config.offload_fs_scheme,
+            container=config.offload_fs_container,
+        )
+        messages.log(f"Logging Offload to log_path: {log_path}")
 
-    # Basic offload of a simple dimension.
-    options = {
-        "owner_table": schema + "." + table_name,
-        "reset_backend_table": True,
-        "create_backend_db": True,
-    }
-    run_offload(
-        options,
-        config,
-        messages,
-        config_overrides={"log_path": log_path},
-        no_messages_override=True,
-    )
+        # Basic offload of a simple dimension.
+        options = {
+            "owner_table": schema + "." + table_name,
+            "reset_backend_table": True,
+            "create_backend_db": True,
+        }
+        run_offload(
+            options,
+            config,
+            messages,
+            config_overrides={"log_path": log_path},
+            no_messages_override=True,
+        )
 
-    assert standard_dimension_assertion(
-        config, backend_api, messages, repo_client, schema, data_db, table_name
-    )
-
-    # Connections are being left open, explicitly close them.
-    frontend_api.close()
+        assert standard_dimension_assertion(
+            config, backend_api, messages, repo_client, schema, data_db, table_name
+        )

--- a/tests/integration/scenarios/test_offload_transport_oracle_iot.py
+++ b/tests/integration/scenarios/test_offload_transport_oracle_iot.py
@@ -1,4 +1,4 @@
-# Copyright 2016 The GOE Authors. All rights reserved.
+# Copyright 2024 The GOE Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Integration tests for Offload Transport specifics."""
+"""Integration tests for Offload Transport IOT specifics."""
 
 import pytest
 
+from goe.config.orchestration_config import OrchestrationConfig
 from goe.offload import offload_constants
 from goe.offload.offload_functions import (
     convert_backend_identifier_case,
@@ -60,7 +61,7 @@ from tests.integration.test_functions import (
 from tests.testlib.test_framework.test_functions import (
     get_backend_testing_api,
     get_frontend_testing_api,
-    get_test_messages,
+    get_test_messages_ctx,
 )
 
 
@@ -80,17 +81,17 @@ SQOOP_TS_DIM = "OT_IOT_TS_SQOOP_DIM"
 
 
 @pytest.fixture
-def config():
+def config() -> OrchestrationConfig:
     return cached_current_options()
 
 
 @pytest.fixture
-def schema():
+def schema() -> str:
     return cached_default_test_user()
 
 
 @pytest.fixture
-def data_db(schema, config):
+def data_db(schema: str, config: OrchestrationConfig) -> str:
     data_db = data_db_name(schema, config)
     data_db = convert_backend_identifier_case(config, data_db)
     return data_db
@@ -310,332 +311,345 @@ def iot_ts_dim_tests(
 #
 # IOT with NUMBER PK
 #
-def test_offload_transport_oracle_iot_num_qi(config, schema, data_db):
+def test_offload_transport_oracle_iot_num_qi(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Query Import."""
     id = "test_offload_transport_oracle_iot_num_qi"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_query_import_available(None, config, None, messages=messages):
+            messages.log(f"Skipping {id} because Query Import is not configured")
+            pytest.skip(f"Skipping {id} because Query Import is not configured")
 
-    if not is_query_import_available(None, config, None, messages=messages):
-        messages.log(f"Skipping {id} because Query Import is not configured")
-        pytest.skip(f"Skipping {id} because Query Import is not configured")
-
-    iot_num_dim_tests(
-        config,
-        schema,
-        data_db,
-        QI_NUM_DIM,
-        OFFLOAD_TRANSPORT_METHOD_QUERY_IMPORT,
-        messages,
-        id,
-        None,
-    )
+        iot_num_dim_tests(
+            config,
+            schema,
+            data_db,
+            QI_NUM_DIM,
+            OFFLOAD_TRANSPORT_METHOD_QUERY_IMPORT,
+            messages,
+            id,
+            None,
+        )
 
 
-def test_offload_transport_oracle_iot_num_dataproc_cluster(config, schema, data_db):
+def test_offload_transport_oracle_iot_num_dataproc_cluster(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Dataproc."""
     id = "test_offload_transport_oracle_iot_num_dataproc_cluster"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_spark_gcloud_dataproc_available(config, None, messages=messages):
+            messages.log(f"Skipping {id} because Dataproc is not configured")
+            pytest.skip(f"Skipping {id} because Dataproc is not configured")
 
-    if not is_spark_gcloud_dataproc_available(config, None, messages=messages):
-        messages.log(f"Skipping {id} because Dataproc is not configured")
-        pytest.skip(f"Skipping {id} because Dataproc is not configured")
-
-    iot_num_dim_tests(
-        config,
-        schema,
-        data_db,
-        DATAPROC_NUM_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SPARK_DATAPROC_GCLOUD,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_NATIVE_RANGE,
-    )
+        iot_num_dim_tests(
+            config,
+            schema,
+            data_db,
+            DATAPROC_NUM_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SPARK_DATAPROC_GCLOUD,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_NATIVE_RANGE,
+        )
 
 
-def test_offload_transport_oracle_iot_num_dataproc_batches(config, schema, data_db):
+def test_offload_transport_oracle_iot_num_dataproc_batches(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Dataproc Batches."""
     id = "test_offload_transport_oracle_iot_num_dataproc_batches"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_spark_gcloud_batches_available(config, None, messages=messages):
+            messages.log(f"Skipping {id} because Dataproc Batches is not configured")
+            pytest.skip(f"Skipping {id} because Dataproc Batches is not configured")
 
-    if not is_spark_gcloud_batches_available(config, None, messages=messages):
-        messages.log(f"Skipping {id} because Dataproc Batches is not configured")
-        pytest.skip(f"Skipping {id} because Dataproc Batches is not configured")
-
-    iot_num_dim_tests(
-        config,
-        schema,
-        data_db,
-        BATCHES_NUM_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SPARK_BATCHES_GCLOUD,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_NATIVE_RANGE,
-    )
+        iot_num_dim_tests(
+            config,
+            schema,
+            data_db,
+            BATCHES_NUM_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SPARK_BATCHES_GCLOUD,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_NATIVE_RANGE,
+        )
 
 
-def test_offload_transport_oracle_iot_num_spark_submit(config, schema, data_db):
+def test_offload_transport_oracle_iot_num_spark_submit(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Spark Submit."""
     id = "test_offload_transport_oracle_iot_num_spark_submit"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_spark_submit_available(config, None, messages=messages):
+            messages.log(f"Skipping {id} because Spark Submit is not configured")
+            pytest.skip(f"Skipping {id} because Spark Submit is not configured")
 
-    if not is_spark_submit_available(config, None, messages=messages):
-        messages.log(f"Skipping {id} because Spark Submit is not configured")
-        pytest.skip(f"Skipping {id} because Spark Submit is not configured")
-
-    iot_num_dim_tests(
-        config,
-        schema,
-        data_db,
-        SPARK_SUBMIT_NUM_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SPARK_SUBMIT,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_ID_RANGE,
-    )
+        iot_num_dim_tests(
+            config,
+            schema,
+            data_db,
+            SPARK_SUBMIT_NUM_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SPARK_SUBMIT,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_ID_RANGE,
+        )
 
 
-def test_offload_transport_oracle_iot_num_sqoop(config, schema, data_db):
+def test_offload_transport_oracle_iot_num_sqoop(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Sqoop."""
     id = "test_offload_transport_oracle_iot_num_sqoop"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_sqoop_available(None, config, messages=messages):
+            messages.log(f"Skipping {id} because Sqoop is not configured")
+            pytest.skip(f"Skipping {id} because Sqoop is not configured")
 
-    if not is_sqoop_available(None, config, messages=messages):
-        messages.log(f"Skipping {id} because Sqoop is not configured")
-        pytest.skip(f"Skipping {id} because Sqoop is not configured")
-
-    iot_num_dim_tests(
-        config,
-        schema,
-        data_db,
-        SQOOP_NUM_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SQOOP,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_ID_RANGE,
-    )
+        iot_num_dim_tests(
+            config,
+            schema,
+            data_db,
+            SQOOP_NUM_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SQOOP,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_ID_RANGE,
+        )
 
 
 #
 # IOT with TIMESTAMP PK
 #
-def test_offload_transport_oracle_iot_ts_dataproc_cluster(config, schema, data_db):
+def test_offload_transport_oracle_iot_ts_dataproc_cluster(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Dataproc."""
     id = "test_offload_transport_oracle_iot_ts_dataproc_cluster"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_spark_gcloud_dataproc_available(config, None, messages=messages):
+            messages.log(f"Skipping {id} because Dataproc is not configured")
+            pytest.skip(f"Skipping {id} because Dataproc is not configured")
 
-    if not is_spark_gcloud_dataproc_available(config, None, messages=messages):
-        messages.log(f"Skipping {id} because Dataproc is not configured")
-        pytest.skip(f"Skipping {id} because Dataproc is not configured")
-
-    iot_ts_dim_tests(
-        config,
-        schema,
-        data_db,
-        DATAPROC_TS_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SPARK_DATAPROC_GCLOUD,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_NATIVE_RANGE,
-    )
+        iot_ts_dim_tests(
+            config,
+            schema,
+            data_db,
+            DATAPROC_TS_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SPARK_DATAPROC_GCLOUD,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_NATIVE_RANGE,
+        )
 
 
-def test_offload_transport_oracle_iot_ts_dataproc_batches(config, schema, data_db):
+def test_offload_transport_oracle_iot_ts_dataproc_batches(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Dataproc Batches."""
     id = "test_offload_transport_oracle_iot_ts_dataproc_batches"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_spark_gcloud_batches_available(config, None, messages=messages):
+            messages.log(f"Skipping {id} because Dataproc Batches is not configured")
+            pytest.skip(f"Skipping {id} because Dataproc Batches is not configured")
 
-    if not is_spark_gcloud_batches_available(config, None, messages=messages):
-        messages.log(f"Skipping {id} because Dataproc Batches is not configured")
-        pytest.skip(f"Skipping {id} because Dataproc Batches is not configured")
-
-    iot_ts_dim_tests(
-        config,
-        schema,
-        data_db,
-        BATCHES_TS_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SPARK_BATCHES_GCLOUD,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_NATIVE_RANGE,
-    )
+        iot_ts_dim_tests(
+            config,
+            schema,
+            data_db,
+            BATCHES_TS_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SPARK_BATCHES_GCLOUD,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_NATIVE_RANGE,
+        )
 
 
-def test_offload_transport_oracle_iot_ts_spark_submit(config, schema, data_db):
+def test_offload_transport_oracle_iot_ts_spark_submit(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Spark Submit."""
     id = "test_offload_transport_oracle_iot_ts_spark_submit"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_spark_submit_available(config, None, messages=messages):
+            messages.log(f"Skipping {id} because Spark Submit is not configured")
+            pytest.skip(f"Skipping {id} because Spark Submit is not configured")
 
-    if not is_spark_submit_available(config, None, messages=messages):
-        messages.log(f"Skipping {id} because Spark Submit is not configured")
-        pytest.skip(f"Skipping {id} because Spark Submit is not configured")
-
-    iot_ts_dim_tests(
-        config,
-        schema,
-        data_db,
-        SPARK_SUBMIT_TS_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SPARK_SUBMIT,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_ID_RANGE,
-    )
+        iot_ts_dim_tests(
+            config,
+            schema,
+            data_db,
+            SPARK_SUBMIT_TS_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SPARK_SUBMIT,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_ID_RANGE,
+        )
 
 
-def test_offload_transport_oracle_iot_ts_sqoop(config, schema, data_db):
+def test_offload_transport_oracle_iot_ts_sqoop(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Sqoop."""
     id = "test_offload_transport_oracle_iot_ts_sqoop"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_sqoop_available(None, config, messages=messages):
+            messages.log(f"Skipping {id} because Sqoop is not configured")
+            pytest.skip(f"Skipping {id} because Sqoop is not configured")
 
-    if not is_sqoop_available(None, config, messages=messages):
-        messages.log(f"Skipping {id} because Sqoop is not configured")
-        pytest.skip(f"Skipping {id} because Sqoop is not configured")
-
-    iot_ts_dim_tests(
-        config,
-        schema,
-        data_db,
-        SQOOP_TS_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SQOOP,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_MOD,
-    )
+        iot_ts_dim_tests(
+            config,
+            schema,
+            data_db,
+            SQOOP_TS_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SQOOP,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_MOD,
+        )
 
 
 #
 # IOT with STRING PK
 #
-def test_offload_transport_oracle_iot_str_dataproc_cluster(config, schema, data_db):
+def test_offload_transport_oracle_iot_str_dataproc_cluster(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Dataproc."""
     id = "test_offload_transport_oracle_iot_str_dataproc_cluster"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_spark_gcloud_dataproc_available(config, None, messages=messages):
+            messages.log(f"Skipping {id} because Dataproc is not configured")
+            pytest.skip(f"Skipping {id} because Dataproc is not configured")
 
-    if not is_spark_gcloud_dataproc_available(config, None, messages=messages):
-        messages.log(f"Skipping {id} because Dataproc is not configured")
-        pytest.skip(f"Skipping {id} because Dataproc is not configured")
-
-    iot_str_dim_tests(
-        config,
-        schema,
-        data_db,
-        DATAPROC_STR_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SPARK_DATAPROC_GCLOUD,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_MOD,
-    )
+        iot_str_dim_tests(
+            config,
+            schema,
+            data_db,
+            DATAPROC_STR_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SPARK_DATAPROC_GCLOUD,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_MOD,
+        )
 
 
-def test_offload_transport_oracle_iot_str_dataproc_batches(config, schema, data_db):
+def test_offload_transport_oracle_iot_str_dataproc_batches(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Dataproc Batches."""
     id = "test_offload_transport_oracle_iot_str_dataproc_batches"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_spark_gcloud_batches_available(config, None, messages=messages):
+            messages.log(f"Skipping {id} because Dataproc Batches is not configured")
+            pytest.skip(f"Skipping {id} because Dataproc Batches is not configured")
 
-    if not is_spark_gcloud_batches_available(config, None, messages=messages):
-        messages.log(f"Skipping {id} because Dataproc Batches is not configured")
-        pytest.skip(f"Skipping {id} because Dataproc Batches is not configured")
-
-    iot_str_dim_tests(
-        config,
-        schema,
-        data_db,
-        BATCHES_STR_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SPARK_BATCHES_GCLOUD,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_MOD,
-    )
+        iot_str_dim_tests(
+            config,
+            schema,
+            data_db,
+            BATCHES_STR_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SPARK_BATCHES_GCLOUD,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_MOD,
+        )
 
 
-def test_offload_transport_oracle_iot_str_spark_submit(config, schema, data_db):
+def test_offload_transport_oracle_iot_str_spark_submit(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Spark Submit."""
     id = "test_offload_transport_oracle_iot_str_spark_submit"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_spark_submit_available(config, None, messages=messages):
+            messages.log(f"Skipping {id} because Spark Submit is not configured")
+            pytest.skip(f"Skipping {id} because Spark Submit is not configured")
 
-    if not is_spark_submit_available(config, None, messages=messages):
-        messages.log(f"Skipping {id} because Spark Submit is not configured")
-        pytest.skip(f"Skipping {id} because Spark Submit is not configured")
-
-    iot_str_dim_tests(
-        config,
-        schema,
-        data_db,
-        SPARK_SUBMIT_STR_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SPARK_SUBMIT,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_MOD,
-    )
+        iot_str_dim_tests(
+            config,
+            schema,
+            data_db,
+            SPARK_SUBMIT_STR_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SPARK_SUBMIT,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_MOD,
+        )
 
 
-def test_offload_transport_oracle_iot_str_sqoop(config, schema, data_db):
+def test_offload_transport_oracle_iot_str_sqoop(
+    config: OrchestrationConfig, schema: str, data_db: str
+):
     """Test IOT offload with Sqoop."""
     id = "test_offload_transport_oracle_iot_str_sqoop"
-    messages = get_test_messages(config, id)
+    with get_test_messages_ctx(config, id) as messages:
+        if config.db_type != offload_constants.DBTYPE_ORACLE:
+            messages.log(f"Skipping {id} for frontend: {config.db_type}")
+            pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
-    if config.db_type != offload_constants.DBTYPE_ORACLE:
-        messages.log(f"Skipping {id} for frontend: {config.db_type}")
-        pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
+        if not is_sqoop_available(None, config, messages=messages):
+            messages.log(f"Skipping {id} because Sqoop is not configured")
+            pytest.skip(f"Skipping {id} because Sqoop is not configured")
 
-    if not is_sqoop_available(None, config, messages=messages):
-        messages.log(f"Skipping {id} because Sqoop is not configured")
-        pytest.skip(f"Skipping {id} because Sqoop is not configured")
-
-    iot_str_dim_tests(
-        config,
-        schema,
-        data_db,
-        SQOOP_STR_DIM,
-        OFFLOAD_TRANSPORT_METHOD_SQOOP,
-        messages,
-        id,
-        TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_MOD,
-    )
+        iot_str_dim_tests(
+            config,
+            schema,
+            data_db,
+            SQOOP_STR_DIM,
+            OFFLOAD_TRANSPORT_METHOD_SQOOP,
+            messages,
+            id,
+            TRANSPORT_ROW_SOURCE_QUERY_SPLIT_BY_MOD,
+        )

--- a/tests/testlib/test_framework/offload_test_messages.py
+++ b/tests/testlib/test_framework/offload_test_messages.py
@@ -14,6 +14,8 @@
 
 """Wrapper over OffloadMessages that has useful methods for inspecting the messages or log."""
 
+from goe.util.goe_log_fh import GOELogFileHandle
+
 
 class OffloadTestMessages:
     def __init__(self, messages):
@@ -41,15 +43,15 @@ class OffloadTestMessages:
             return []
         start_found = bool(not search_from_text)
         matches = []
-        lf = open(log_file, "r")
-        for line in lf:
-            if not start_found:
-                start_found = search_from_text in line
-            else:
-                if search_text in line:
-                    matches.append(line)
-                    if max_matches and len(matches) >= max_matches:
-                        return matches
+        with GOELogFileHandle(log_file, mode="r") as lf:
+            for line in lf:
+                if not start_found:
+                    start_found = search_from_text in line
+                else:
+                    if search_text in line:
+                        matches.append(line)
+                        if max_matches and len(matches) >= max_matches:
+                            return matches
         return matches
 
     def get_line_from_log(self, search_text, search_from_text="") -> str:
@@ -64,6 +66,9 @@ class OffloadTestMessages:
     ###########################################################################
     # PASSTHROUGH PUBLIC METHODS
     ###########################################################################
+
+    def close_log(self, *args, **kwargs):
+        return self._messages.close_log(*args, **kwargs)
 
     def debug(self, *args, **kwargs):
         return self._messages.debug(*args, **kwargs)

--- a/tests/testlib/test_framework/test_functions.py
+++ b/tests/testlib/test_framework/test_functions.py
@@ -18,19 +18,17 @@
     Allows us to share code but also keep scripts trim and healthy.
 """
 
-import re
+from contextlib import contextmanager
 
 from goe.goe import (
     get_log_fh_name,
     log as offload_log,
     normal,
-    verbose,
-    vverbose,
 )
-from goe.offload.column_metadata import match_table_column
 from goe.offload.offload_constants import DBTYPE_ORACLE
 from goe.offload.offload_functions import convert_backend_identifier_case, data_db_name
-from goe.offload.offload_messages import OffloadMessages, VERBOSE
+from goe.offload.offload_messages import OffloadMessages
+from goe.util.goe_log_fh import GOELogFileHandle
 from tests.testlib.test_framework.factory.backend_testing_api_factory import (
     backend_testing_api_factory,
 )
@@ -61,10 +59,28 @@ def get_frontend_testing_api(config, messages, trace_action=None):
     )
 
 
+@contextmanager
+def get_frontend_testing_api_ctx(config, messages, trace_action=None):
+    frontend_api = get_frontend_testing_api(config, messages, trace_action=trace_action)
+    try:
+        yield frontend_api
+    finally:
+        frontend_api.close()
+
+
 def get_test_messages(config, test_id, execution_id=None):
     messages = OffloadMessages(execution_id=execution_id)
     messages.init_log(config.log_path, test_id)
     return OffloadTestMessages(messages)
+
+
+@contextmanager
+def get_test_messages_ctx(config, test_id, execution_id=None):
+    messages = get_test_messages(config, test_id, execution_id=execution_id)
+    try:
+        yield messages
+    finally:
+        messages.close_log()
 
 
 def get_data_db_for_schema(schema, config):
@@ -84,15 +100,15 @@ def get_lines_from_log(
     # We can't log search_text otherwise we put the very thing we are searching for in the log
     start_found = False if search_from_text else True
     matches = []
-    lf = open(log_file, "r")
-    for line in lf:
-        if not start_found:
-            start_found = search_from_text in line
-        else:
-            if search_text in line:
-                matches.append(line)
-                if max_matches and len(matches) >= max_matches:
-                    return matches
+    with GOELogFileHandle(log_file, mode="r") as lf:
+        for line in lf:
+            if not start_found:
+                start_found = search_from_text in line
+            else:
+                if search_text in line:
+                    matches.append(line)
+                    if max_matches and len(matches) >= max_matches:
+                        return matches
     return matches
 
 

--- a/tests/unit/offload/test_offload_messages.py
+++ b/tests/unit/offload/test_offload_messages.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import TestCase, main
+from datetime import timedelta
 
 from goe.config import orchestration_defaults
 from goe.offload.offload_messages import (
@@ -22,6 +22,9 @@ from goe.offload.offload_messages import (
     VVERBOSE,
 )
 from goe.orchestration import command_steps, orchestration_constants
+from goe.util.goe_log_fh import GOELogFileHandle
+
+import pytest
 
 
 class FakeOpts(object):
@@ -43,131 +46,136 @@ class FakeOpts(object):
         return vars(self)
 
 
-class TestOffloadMessages(TestCase):
-    def _std_messages_actions(self, messages):
-        """Shake down messages calls.
-        It would be better if we actually checked what was written a log file vs stdout but, at the moment,
-        all we are doing is ensuring no unexpected exceptions.
-        """
-        messages.log("msg")
-        messages.log("vmsg", detail=VERBOSE)
-        messages.log("vvmsg", detail=VVERBOSE)
-        messages.info("info", detail=VVERBOSE)
-        messages.info("vinfo", detail=VERBOSE)
-        messages.info("vvinfo", detail=VVERBOSE)
-        messages.debug("debug", detail=VVERBOSE)
-        messages.debug("vdebug", detail=VERBOSE)
-        messages.debug("vvdebug", detail=VVERBOSE)
-        messages.notice("a-notice")
-        self.assertIn("a-notice", messages.get_notices())
-        self.assertIn("a-notice", messages.get_messages())
-        messages.warning("a-warning")
-        self.assertIn("a-warning", messages.get_warnings())
-        self.assertIn("a-warning", messages.get_messages())
-        messages.event("an-event")
-        self.assertIn("an-event", messages.get_events())
+def _std_messages_actions(messages):
+    """Shake down messages calls.
+    It would be better if we actually checked what was written a log file vs stdout but, at the moment,
+    all we are doing is ensuring no unexpected exceptions.
+    """
+    messages.log("msg")
+    messages.log("vmsg", detail=VERBOSE)
+    messages.log("vvmsg", detail=VVERBOSE)
+    messages.info("info", detail=VVERBOSE)
+    messages.info("vinfo", detail=VERBOSE)
+    messages.info("vvinfo", detail=VVERBOSE)
+    messages.debug("debug", detail=VVERBOSE)
+    messages.debug("vdebug", detail=VERBOSE)
+    messages.debug("vvdebug", detail=VVERBOSE)
+    messages.notice("a-notice")
+    assert "a-notice" in messages.get_notices()
+    assert "a-notice" in messages.get_messages()
+    messages.warning("a-warning")
+    assert "a-warning" in messages.get_warnings()
+    assert "a-warning" in messages.get_messages()
+    messages.warning("Honk honk", ansi_code="red")
+    messages.event("an-event")
+    assert "an-event" in messages.get_events()
 
-    def test_from_options(self):
-        with open("/dev/null", "a") as fh:
-            messages = OffloadMessages.from_options(FakeOpts(), log_fh=fh)
-            self._std_messages_actions(messages)
 
-    def test_from_options_dict(self):
-        with open("/dev/null", "a") as fh:
-            messages = OffloadMessages.from_options_dict(
-                FakeOpts().as_dict(), log_fh=fh
-            )
-            self._std_messages_actions(messages)
+def test_from_options():
+    log_file = "/tmp/test_from_options.tmp"
+    with GOELogFileHandle(log_file) as fh:
+        messages = OffloadMessages.from_options(FakeOpts(), log_fh=fh)
+        _std_messages_actions(messages)
 
-    def test_offload_step(self):
-        def do_nothing():
-            pass
 
-        def do_divzero():
-            return 1 / 0
+def test_from_options_dict():
+    log_file = "/tmp/test_from_options_dict.tmp"
+    with GOELogFileHandle(log_file) as fh:
+        messages = OffloadMessages.from_options_dict(FakeOpts().as_dict(), log_fh=fh)
+        _std_messages_actions(messages)
 
-        with open("/dev/null", "a") as fh:
-            # Sanity check with no modifiers, all steps recorded
-            messages = OffloadMessages.from_options(FakeOpts(), log_fh=fh)
-            messages.offload_step(
-                command_steps.STEP_MESSAGES,
-                do_nothing,
-                command_type=orchestration_constants.COMMAND_TEST,
-            )
-            messages.offload_step(
-                command_steps.STEP_UNITTEST_SKIP,
-                do_nothing,
-                command_type=orchestration_constants.COMMAND_TEST,
-            )
+
+def test_step_delta():
+    log_file = "/tmp/test_step_delta.tmp"
+    with GOELogFileHandle(log_file) as fh:
+        messages = OffloadMessages.from_options(FakeOpts(), log_fh=fh)
+        messages.step_delta("Normal Stuff", timedelta(0, 160, 615919))
+        messages.log("Honk honk", ansi_code="red")
+        messages.step_delta("Bad Stuff", timedelta(0, 130, 651717))
+        messages.warning("Honk honk", ansi_code="red")
+        messages.step_delta("Bad Stuff", timedelta(0, 9101, 651717))
+        messages.log_step_deltas()
+
+
+def test_offload_step():
+    def do_nothing():
+        pass
+
+    def do_divzero():
+        return 1 / 0
+
+    with open("/dev/null", "a") as fh:
+        # Sanity check with no modifiers, all steps recorded
+        messages = OffloadMessages.from_options(FakeOpts(), log_fh=fh)
+        messages.offload_step(
+            command_steps.STEP_MESSAGES,
+            do_nothing,
+            command_type=orchestration_constants.COMMAND_TEST,
+        )
+        messages.offload_step(
+            command_steps.STEP_UNITTEST_SKIP,
+            do_nothing,
+            command_type=orchestration_constants.COMMAND_TEST,
+        )
+        messages.offload_step(
+            command_steps.STEP_UNITTEST_ERROR_BEFORE,
+            do_nothing,
+            command_type=orchestration_constants.COMMAND_TEST,
+        )
+        messages.offload_step(
+            command_steps.STEP_UNITTEST_ERROR_AFTER,
+            do_nothing,
+            command_type=orchestration_constants.COMMAND_TEST,
+        )
+        # Now check that step interaction works
+        messages_title = command_steps.step_title(command_steps.STEP_MESSAGES)
+        skip_title = command_steps.step_title(command_steps.STEP_UNITTEST_SKIP)
+        error_before_title = command_steps.step_title(
+            command_steps.STEP_UNITTEST_ERROR_BEFORE
+        )
+        error_after_title = command_steps.step_title(
+            command_steps.STEP_UNITTEST_ERROR_AFTER
+        )
+        messages = OffloadMessages.from_options(FakeOpts(), log_fh=fh)
+        messages.setup_offload_step(
+            skip=[skip_title.replace(" ", "_").lower()],
+            error_before_step=error_before_title.replace(" ", "_").lower(),
+            error_after_step=error_after_title.replace(" ", "_").lower(),
+        )
+        # Normal step should be recorded in steps
+        messages.offload_step(
+            command_steps.STEP_MESSAGES,
+            do_nothing,
+            command_type=orchestration_constants.COMMAND_TEST,
+        )
+        assert messages_title in messages.steps
+        # Skipped step should not be in recorded steps
+        messages.offload_step(
+            command_steps.STEP_UNITTEST_SKIP,
+            do_nothing,
+            command_type=orchestration_constants.COMMAND_TEST,
+        )
+        assert skip_title not in messages.steps
+        # Check test assertion thrown
+        with pytest.raises(OffloadMessagesForcedException) as _:
             messages.offload_step(
                 command_steps.STEP_UNITTEST_ERROR_BEFORE,
                 do_nothing,
                 command_type=orchestration_constants.COMMAND_TEST,
             )
+        assert error_before_title not in messages.steps
+        with pytest.raises(OffloadMessagesForcedException) as _:
             messages.offload_step(
                 command_steps.STEP_UNITTEST_ERROR_AFTER,
                 do_nothing,
                 command_type=orchestration_constants.COMMAND_TEST,
             )
-            # Now check that step interaction works
-            messages_title = command_steps.step_title(command_steps.STEP_MESSAGES)
-            skip_title = command_steps.step_title(command_steps.STEP_UNITTEST_SKIP)
-            error_before_title = command_steps.step_title(
-                command_steps.STEP_UNITTEST_ERROR_BEFORE
-            )
-            error_after_title = command_steps.step_title(
-                command_steps.STEP_UNITTEST_ERROR_AFTER
-            )
-            messages = OffloadMessages.from_options(FakeOpts(), log_fh=fh)
-            messages.setup_offload_step(
-                skip=[skip_title.replace(" ", "_").lower()],
-                error_before_step=error_before_title.replace(" ", "_").lower(),
-                error_after_step=error_after_title.replace(" ", "_").lower(),
-            )
-            # Normal step should be recorded in steps
+        assert error_after_title in messages.steps
+        # Check flow when a genuine exception is encountered, we should still get that exception and
+        # not suffer a subsequent issue in our handling code
+        with pytest.raises(ZeroDivisionError) as _:
             messages.offload_step(
                 command_steps.STEP_MESSAGES,
-                do_nothing,
+                do_divzero,
                 command_type=orchestration_constants.COMMAND_TEST,
             )
-            self.assertIn(messages_title, messages.steps)
-            # Skipped step should not be in recorded steps
-            messages.offload_step(
-                command_steps.STEP_UNITTEST_SKIP,
-                do_nothing,
-                command_type=orchestration_constants.COMMAND_TEST,
-            )
-            self.assertNotIn(skip_title, messages.steps)
-            # Check test assertion thrown
-            self.assertRaises(
-                OffloadMessagesForcedException,
-                lambda: messages.offload_step(
-                    command_steps.STEP_UNITTEST_ERROR_BEFORE,
-                    do_nothing,
-                    command_type=orchestration_constants.COMMAND_TEST,
-                ),
-            )
-            self.assertNotIn(error_before_title, messages.steps)
-            self.assertRaises(
-                OffloadMessagesForcedException,
-                lambda: messages.offload_step(
-                    command_steps.STEP_UNITTEST_ERROR_AFTER,
-                    do_nothing,
-                    command_type=orchestration_constants.COMMAND_TEST,
-                ),
-            )
-            self.assertIn(error_after_title, messages.steps)
-            # Check flow when a genuine exception is encountered, we should still get that exception and
-            # not suffer a subsequent issue in our handling code
-            self.assertRaises(
-                ZeroDivisionError,
-                lambda: messages.offload_step(
-                    command_steps.STEP_MESSAGES,
-                    do_divzero,
-                    command_type=orchestration_constants.COMMAND_TEST,
-                ),
-            )
-
-
-if __name__ == "__main__":
-    main()

--- a/tests/unit/offload/test_offload_transport_functions.py
+++ b/tests/unit/offload/test_offload_transport_functions.py
@@ -12,162 +12,191 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" TestOffloadTransportFunctions: Unit test library to test global functions defined in offload_transport_functions.py
-"""
-from unittest import TestCase, main
+import pytest
 
-from goe.offload.offload_transport_functions import (
-    running_as_same_user_and_host,
-    offload_transport_file_name,
-    split_lists_for_id_list,
-    split_ranges_for_id_range,
-)
+import goe.offload.offload_transport_functions as module_under_test
 from goe.util.misc_functions import get_os_username, LINUX_FILE_NAME_LENGTH_LIMIT
 
-
-class TestOffloadTransportFunctions(TestCase):
-    def running_as_same_user_and_host(self):
-        self.assertNotIn(
-            "ssh", running_as_same_user_and_host(get_os_username(), "localhost")
-        )
-        self.assertIn(
-            "ssh", running_as_same_user_and_host(get_os_username(), "other-host")
-        )
-        self.assertIn("ssh", running_as_same_user_and_host("other-user", "localhost"))
-
-    def test_offload_transport_file_name(self):
-        std_prefix = "db_name.table_name"
-        self.assertEqual(offload_transport_file_name(std_prefix), std_prefix)
-        self.assertTrue(
-            len(offload_transport_file_name(std_prefix, extension=".dat"))
-            < LINUX_FILE_NAME_LENGTH_LIMIT
-        )
-
-        long_prefix = "db_name".ljust(128, "x") + "." + "table_name".ljust(128, "x")
-        # long_prefix would need to be truncated
-        self.assertNotEqual(offload_transport_file_name(long_prefix), long_prefix)
-        self.assertTrue(
-            offload_transport_file_name(long_prefix).startswith(long_prefix[:200])
-        )
-        # long_prefix would need to be truncated but extension still honoured
-        self.assertTrue(
-            offload_transport_file_name(long_prefix).startswith(long_prefix[:200])
-        )
-        self.assertFalse(
-            offload_transport_file_name(long_prefix, extension="").endswith(".dat")
-        )
-        self.assertTrue(
-            len(offload_transport_file_name(long_prefix, extension=""))
-            == LINUX_FILE_NAME_LENGTH_LIMIT
-        )
-        self.assertTrue(
-            offload_transport_file_name(long_prefix, extension=".dat").endswith(".dat")
-        )
-        self.assertTrue(
-            len(offload_transport_file_name(long_prefix, extension=".dat"))
-            == LINUX_FILE_NAME_LENGTH_LIMIT
-        )
-        self.assertRaises(
-            AssertionError, lambda: offload_transport_file_name("file/name")
-        )
-        self.assertRaises(AssertionError, lambda: offload_transport_file_name(123))
-        self.assertRaises(AssertionError, lambda: offload_transport_file_name(None))
-        self.assertRaises(
-            AssertionError,
-            lambda: offload_transport_file_name("file_name", extension=None),
-        )
-        self.assertRaises(
-            AssertionError,
-            lambda: offload_transport_file_name("file_name", extension=123),
-        )
-
-    def test_split_ranges_for_id_range(self):
-        test_data = [
-            # Simple range of 1-10 with assorted parallelism
-            ((1, 10, 1), [(1, 11)]),
-            ((1, 10, 2), [(1, 6), (6, 11)]),
-            ((1, 10, 5), [(1, 3), (3, 5), (5, 7), (7, 9), (9, 11)]),
-            # Range with min == max and assorted parallelism
-            ((1, 1, 1), [(1, 2)]),
-            ((1, 1, 2), [(1, 1.5), (1.5, 2)]),
-            ((0, 0, 1), [(0, 1)]),
-            ((0, 0, 4), [(0, 0.25), (0.25, 0.5), (0.5, 0.75), (0.75, 1)]),
-            # Range smaller than parallelism - what should we do?
-            ((1, 2, 4), [(1, 1.5), (1.5, 2), (2, 2.5), (2.5, 3)]),
-            # Bigger inputs that overflow float
-            (
-                (9999999999999991, 9999999999999999, 1),
-                [(9999999999999991, 10000000000000000)],
-            ),
-            (
-                (int(("9" * 30) + "000"), int(("9" * 30) + "999"), 4),
-                [
-                    (int(("9" * 30) + "000"), int(("9" * 30) + "250")),
-                    (int(("9" * 30) + "250"), int(("9" * 30) + "500")),
-                    (int(("9" * 30) + "500"), int(("9" * 30) + "750")),
-                    (int(("9" * 30) + "750"), int("1" + ("0" * 30) + "000")),
-                ],
-            ),
-        ]
-        for inputs, expected_result in test_data:
-            result = split_ranges_for_id_range(*inputs)
-            self.assertEqual(
-                result,
-                expected_result,
-                f"Inputs: min={inputs[0]}, max={inputs[1]}, parallel={inputs[2]}",
-            )
-            for i in range(inputs[0], inputs[1] + 1):
-                # Assert that for each integer between min/max there is only a single capturing range
-                capturing_ranges = [_ for _ in result if _[0] <= i < _[1]]
-                self.assertEqual(
-                    len(capturing_ranges),
-                    1,
-                    f"Value {i} in capturing ranges = {capturing_ranges}",
-                )
-
-    def test_split_lists_for_id_list(self):
-        test_data = [
-            # Round robin, CSV=False
-            [[8, 4, 1, 3, 6, 9], 1, True, False, [[8, 4, 1, 3, 6, 9]]],
-            [[8, 4, 1, 3, 6, 9], 2, True, False, [[8, 1, 6], [4, 3, 9]]],
-            [[8, 4, 1, 3, 6, 9], 3, True, False, [[8, 3], [4, 6], [1, 9]]],
-            [[8, 4, 1, 3, 6], 1, True, False, [[8, 4, 1, 3, 6]]],
-            [[8, 4, 1, 3, 6], 2, True, False, [[8, 1, 6], [4, 3]]],
-            [[8, 4, 1, 3, 6], 3, True, False, [[8, 3], [4, 6], [1]]],
-            [[8], 1, True, False, [[8]]],
-            [[8], 2, True, False, [[8], []]],
-            [[8], 3, True, False, [[8], [], []]],
-            # Round robin, CSV=True
-            [[8, 4, 1, 3, 6, 9], 1, True, True, ["8,4,1,3,6,9"]],
-            [[8, 4, 1, 3, 6, 9], 2, True, True, ["8,1,6", "4,3,9"]],
-            [[8, 4, 1, 3, 6, 9], 3, True, True, ["8,3", "4,6", "1,9"]],
-            [[8, 4, 1, 3, 6], 1, True, True, ["8,4,1,3,6"]],
-            [[8, 4, 1, 3, 6], 2, True, True, ["8,1,6", "4,3"]],
-            [[8, 4, 1, 3, 6], 3, True, True, ["8,3", "4,6", "1"]],
-            [[8], 1, True, True, ["8"]],
-            [[8], 2, True, True, ["8", None]],
-            [[8], 3, True, True, ["8", None, None]],
-            # Contiguous, CSV=False
-            [[8, 4, 1, 3, 6, 9], 1, False, False, [[8, 4, 1, 3, 6, 9]]],
-            [[8, 4, 1, 3, 6, 9], 2, False, False, [[8, 4, 1], [3, 6, 9]]],
-            [[8, 4, 1, 3, 6, 9], 3, False, False, [[8, 4], [1, 3], [6, 9]]],
-            [[8, 4, 1, 3, 6], 1, False, False, [[8, 4, 1, 3, 6]]],
-            [[8, 4, 1, 3, 6], 2, False, False, [[8, 4, 1], [3, 6]]],
-            [[8, 4, 1, 3, 6], 3, False, False, [[8, 4], [1, 3], [6]]],
-            [[8], 1, False, False, [[8]]],
-            [[8], 2, False, False, [[8], []]],
-            [[8], 3, False, False, [[8], [], []]],
-        ]
-        for input_list, parallelism, round_robin, csv, expected_result in test_data:
-            result = split_lists_for_id_list(
-                input_list, parallelism, round_robin=round_robin, as_csvs=csv
-            )
-            self.assertEqual(
-                result,
-                expected_result,
-                f"Input: ids={input_list}, parallel={parallelism}, round_robin={round_robin}, csv={csv}",
-            )
+from tests.unit.test_functions import (
+    build_mock_options,
+    FAKE_ORACLE_BQ_ENV,
+)
 
 
-if __name__ == "__main__":
-    main()
+def test_running_as_same_user_and_host():
+    assert module_under_test.running_as_same_user_and_host(
+        get_os_username(), "localhost"
+    )
+    assert not module_under_test.running_as_same_user_and_host(
+        get_os_username(), "other-host"
+    )
+    assert not module_under_test.running_as_same_user_and_host(
+        "other-user", "localhost"
+    )
+
+
+def test_offload_transport_file_name():
+    std_prefix = "db_name.table_name"
+    assert module_under_test.offload_transport_file_name(std_prefix) == std_prefix
+    assert (
+        len(module_under_test.offload_transport_file_name(std_prefix, extension=".dat"))
+        < LINUX_FILE_NAME_LENGTH_LIMIT
+    )
+
+    long_prefix = "db_name".ljust(128, "x") + "." + "table_name".ljust(128, "x")
+    # long_prefix would need to be truncated
+    assert module_under_test.offload_transport_file_name(long_prefix) != long_prefix
+    assert module_under_test.offload_transport_file_name(long_prefix).startswith(
+        long_prefix[:200]
+    )
+    # long_prefix would need to be truncated but extension still honoured
+    assert module_under_test.offload_transport_file_name(long_prefix).startswith(
+        long_prefix[:200]
+    )
+    assert not module_under_test.offload_transport_file_name(
+        long_prefix, extension=""
+    ).endswith(".dat")
+    assert (
+        len(module_under_test.offload_transport_file_name(long_prefix, extension=""))
+        == LINUX_FILE_NAME_LENGTH_LIMIT
+    )
+    assert module_under_test.offload_transport_file_name(
+        long_prefix, extension=".dat"
+    ).endswith(".dat")
+    assert (
+        len(
+            module_under_test.offload_transport_file_name(long_prefix, extension=".dat")
+        )
+        == LINUX_FILE_NAME_LENGTH_LIMIT
+    )
+    with pytest.raises(AssertionError) as _:
+        module_under_test.offload_transport_file_name("file/name")
+    with pytest.raises(AssertionError) as _:
+        module_under_test.offload_transport_file_name(123)
+    with pytest.raises(AssertionError) as _:
+        module_under_test.offload_transport_file_name(None)
+    with pytest.raises(AssertionError) as _:
+        module_under_test.offload_transport_file_name("file_name", extension=None)
+    with pytest.raises(AssertionError) as _:
+        module_under_test.offload_transport_file_name("file_name", extension=123)
+
+
+@pytest.mark.parametrize(
+    "inputs,expected_result",
+    [
+        # Simple range of 1-10 with assorted parallelism
+        ((1, 10, 1), [(1, 11)]),
+        ((1, 10, 2), [(1, 6), (6, 11)]),
+        ((1, 10, 5), [(1, 3), (3, 5), (5, 7), (7, 9), (9, 11)]),
+        # Range with min == max and assorted parallelism
+        ((1, 1, 1), [(1, 2)]),
+        ((1, 1, 2), [(1, 1.5), (1.5, 2)]),
+        ((0, 0, 1), [(0, 1)]),
+        ((0, 0, 4), [(0, 0.25), (0.25, 0.5), (0.5, 0.75), (0.75, 1)]),
+        # Range smaller than parallelism - what should we do?
+        ((1, 2, 4), [(1, 1.5), (1.5, 2), (2, 2.5), (2.5, 3)]),
+        # Bigger inputs that overflow float
+        (
+            (9999999999999991, 9999999999999999, 1),
+            [(9999999999999991, 10000000000000000)],
+        ),
+        (
+            (int(("9" * 30) + "000"), int(("9" * 30) + "999"), 4),
+            [
+                (int(("9" * 30) + "000"), int(("9" * 30) + "250")),
+                (int(("9" * 30) + "250"), int(("9" * 30) + "500")),
+                (int(("9" * 30) + "500"), int(("9" * 30) + "750")),
+                (int(("9" * 30) + "750"), int("1" + ("0" * 30) + "000")),
+            ],
+        ),
+    ],
+)
+def test_split_ranges_for_id_range(inputs, expected_result):
+    result = module_under_test.split_ranges_for_id_range(*inputs)
+    assert (
+        result == expected_result
+    ), f"Inputs: min={inputs[0]}, max={inputs[1]}, parallel={inputs[2]}"
+    for i in range(inputs[0], inputs[1] + 1):
+        # Assert that for each integer between min/max there is only a single capturing range
+        capturing_ranges = [_ for _ in result if _[0] <= i < _[1]]
+        assert (
+            len(capturing_ranges) == 1
+        ), f"Value {i} in capturing ranges = {capturing_ranges}"
+
+
+@pytest.mark.parametrize(
+    "input_list, parallelism, round_robin, csv, expected_result",
+    [
+        # Round robin, CSV=False
+        ([8, 4, 1, 3, 6, 9], 1, True, False, [[8, 4, 1, 3, 6, 9]]),
+        ([8, 4, 1, 3, 6, 9], 2, True, False, [[8, 1, 6], [4, 3, 9]]),
+        ([8, 4, 1, 3, 6, 9], 3, True, False, [[8, 3], [4, 6], [1, 9]]),
+        ([8, 4, 1, 3, 6], 1, True, False, [[8, 4, 1, 3, 6]]),
+        ([8, 4, 1, 3, 6], 2, True, False, [[8, 1, 6], [4, 3]]),
+        ([8, 4, 1, 3, 6], 3, True, False, [[8, 3], [4, 6], [1]]),
+        ([8], 1, True, False, [[8]]),
+        ([8], 2, True, False, [[8], []]),
+        ([8], 3, True, False, [[8], [], []]),
+        # Round robin, CSV=True
+        ([8, 4, 1, 3, 6, 9], 1, True, True, ["8,4,1,3,6,9"]),
+        ([8, 4, 1, 3, 6, 9], 2, True, True, ["8,1,6", "4,3,9"]),
+        ([8, 4, 1, 3, 6, 9], 3, True, True, ["8,3", "4,6", "1,9"]),
+        ([8, 4, 1, 3, 6], 1, True, True, ["8,4,1,3,6"]),
+        ([8, 4, 1, 3, 6], 2, True, True, ["8,1,6", "4,3"]),
+        ([8, 4, 1, 3, 6], 3, True, True, ["8,3", "4,6", "1"]),
+        ([8], 1, True, True, ["8"]),
+        ([8], 2, True, True, ["8", None]),
+        ([8], 3, True, True, ["8", None, None]),
+        # Contiguous, CSV=False
+        ([8, 4, 1, 3, 6, 9], 1, False, False, [[8, 4, 1, 3, 6, 9]]),
+        ([8, 4, 1, 3, 6, 9], 2, False, False, [[8, 4, 1], [3, 6, 9]]),
+        ([8, 4, 1, 3, 6, 9], 3, False, False, [[8, 4], [1, 3], [6, 9]]),
+        ([8, 4, 1, 3, 6], 1, False, False, [[8, 4, 1, 3, 6]]),
+        ([8, 4, 1, 3, 6], 2, False, False, [[8, 4, 1], [3, 6]]),
+        ([8, 4, 1, 3, 6], 3, False, False, [[8, 4], [1, 3], [6]]),
+        ([8], 1, False, False, [[8]]),
+        ([8], 2, False, False, [[8], []]),
+        ([8], 3, False, False, [[8], [], []]),
+    ],
+)
+def test_split_lists_for_id_list(
+    input_list, parallelism, round_robin, csv, expected_result
+):
+    result = module_under_test.split_lists_for_id_list(
+        input_list, parallelism, round_robin=round_robin, as_csvs=csv
+    )
+    assert (
+        result == expected_result
+    ), f"Input: ids={input_list}, parallel={parallelism}, round_robin={round_robin}, csv={csv}"
+
+
+def test_get_local_staging_path_local():
+    target_owner = "owner"
+    table_name = "username"
+    extension = ".ext"
+    config = build_mock_options(FAKE_ORACLE_BQ_ENV)
+    config.log_path = "/this/that/tother"
+    f = module_under_test.get_local_staging_path(
+        target_owner, table_name, config, extension
+    )
+    assert target_owner in f
+    assert table_name in f
+    assert config.log_path in f
+    assert "/tmp" not in f
+    assert f.endswith(extension)
+
+
+def test_get_local_staging_path_gcs():
+    target_owner = "owner"
+    table_name = "username"
+    extension = ".ext"
+    config = build_mock_options(FAKE_ORACLE_BQ_ENV)
+    config.log_path = "gs://bucket/this/that/tother"
+    f = module_under_test.get_local_staging_path(
+        target_owner, table_name, config, extension
+    )
+    assert target_owner in f
+    assert table_name in f
+    assert config.log_path not in f
+    assert "/tmp" in f
+    assert f.endswith(extension)


### PR DESCRIPTION
This PR will add support for log files to be written to Google Cloud Storage via the existing environment variable `OFFLOAD_LOGDIR`. Initially we only support GCS, support for other cloud vendors can be added in the future if required.

For the time being our tests do not support a GCS based `OFFLOAD_LOGDIR`, I've raised issue https://github.com/gluent/goe/issues/198 for this work.