### PR TITLE
test: Tests write to own log file

### DIFF
--- a/src/goe/offload/offload_transport.py
+++ b/src/goe/offload/offload_transport.py
@@ -1621,7 +1621,7 @@ class OffloadTransportSpark(OffloadTransport, metaclass=ABCMeta):
             password_snippet = get_password_snippet()
 
         # Certain config should not be logged
-        config_blacklist = [
+        config_nolog = [
             "spark.jdbc.password",
             "spark.authenticate.secret",
             "spark.hadoop.fs.gs.auth.service.account.private.key",
@@ -1635,13 +1635,13 @@ class OffloadTransportSpark(OffloadTransport, metaclass=ABCMeta):
         ]
         debug_conf_snippet = dedent(
             """\
-                                    config_blacklist = %s
+                                    config_nolog = %s
                                     for kv in sorted(spark.sparkContext.getConf().getAll()):
-                                        if kv[0] in config_blacklist:
+                                        if kv[0] in config_nolog:
                                             print(kv[0], '?')
                                         else:
                                             print(kv)"""
-            % repr(config_blacklist)
+            % repr(config_nolog)
         )
 
         params = {

--- a/tests/integration/scenarios/assertion_functions.py
+++ b/tests/integration/scenarios/assertion_functions.py
@@ -62,7 +62,6 @@ def hint_text_in_log(
     offload_messages: "OffloadMessages",
     config: "OrchestrationConfig",
     parallelism: int,
-    search_from_text,
 ):
     if config.db_type == DBTYPE_ORACLE:
         hint = (
@@ -70,9 +69,7 @@ def hint_text_in_log(
             if parallelism in (0, 1)
             else "PARALLEL({})".format(str(parallelism))
         )
-        return bool(
-            test_functions.get_line_from_log(offload_messages, hint, search_from_text)
-        )
+        return bool(test_functions.get_line_from_log(offload_messages, hint))
     else:
         return False
 
@@ -596,9 +593,10 @@ def sales_based_fact_assertion(
     elif offload_pattern == OFFLOAD_PATTERN_100_0:
         offload_type = OFFLOAD_TYPE_FULL
         incremental_key = None
-        check_fn = lambda mt: bool(
-            not mt.incremental_key and not mt.incremental_high_value
-        )
+
+        def check_fn(mt):
+            return bool(not mt.incremental_key and not mt.incremental_high_value)
+
     elif offload_pattern == OFFLOAD_PATTERN_100_10:
         offload_type = OFFLOAD_TYPE_FULL
 

--- a/tests/integration/scenarios/assertion_functions.py
+++ b/tests/integration/scenarios/assertion_functions.py
@@ -55,10 +55,11 @@ if TYPE_CHECKING:
     from goe.config.orchestration_config import OrchestrationConfig
     from testlib.test_framework.backend_testing_api import BackendTestingApiInterface
     from testlib.test_framework.frontend_testing_api import FrontendTestingApiInterface
+    from testlib.test_framework.offload_test_messages import OffloadTestMessages
 
 
 def hint_text_in_log(
-    messages: "OffloadMessages",
+    offload_messages: "OffloadMessages",
     config: "OrchestrationConfig",
     parallelism: int,
     search_from_text,
@@ -69,47 +70,64 @@ def hint_text_in_log(
             if parallelism in (0, 1)
             else "PARALLEL({})".format(str(parallelism))
         )
-        return bool(messages.get_line_from_log(hint, search_from_text))
+        return bool(
+            test_functions.get_line_from_log(offload_messages, hint, search_from_text)
+        )
     else:
         return False
 
 
 def text_in_log(
-    messages: "OffloadMessages", search_text: str, search_from_text=""
+    offload_messages: "OffloadMessages",
+    search_text: str,
+    test_messages: "OffloadTestMessages",
+    search_from_text="",
 ) -> bool:
     # Do not log search_text below because that is a sure fire way to break the check.
-    messages.log(f'text_in_log(">8 snip 8<", "{search_from_text}")', detail=VERBOSE)
+    test_messages.log(
+        f'text_in_log(">8 snip 8<", "{search_from_text}")', detail=VERBOSE
+    )
     return bool(
-        messages.get_line_from_log(search_text, search_from_text=search_from_text)
+        test_functions.get_line_from_log(
+            offload_messages, search_text, search_from_text=search_from_text
+        )
     )
 
 
-def text_in_events(messages, message_token) -> bool:
-    messages.log(f"text_in_events({message_token})", detail=VERBOSE)
-    return test_functions.text_in_events(messages, message_token)
+def text_in_events(
+    offload_messages: "OffloadMessages",
+    message_token,
+    test_messages: "OffloadTestMessages",
+) -> bool:
+    test_messages.log(f"text_in_events({message_token})", detail=VERBOSE)
+    return test_functions.text_in_events(offload_messages, message_token)
 
 
-def text_in_messages(messages, log_text) -> bool:
-    messages.log(f"text_in_messages({log_text})", detail=VERBOSE)
-    return test_functions.text_in_messages(messages, log_text)
+def text_in_messages(
+    offload_messages: "OffloadMessages", log_text, test_messages: "OffloadTestMessages"
+) -> bool:
+    test_messages.log(f"text_in_messages({log_text})", detail=VERBOSE)
+    return test_functions.text_in_messages(offload_messages, log_text)
 
 
-def messages_step_executions(messages, step_text) -> int:
+def messages_step_executions(
+    offload_messages: "OffloadMessages", step_text, test_messages: "OffloadTestMessages"
+) -> int:
     """Return the number of times step "step_text" was executed."""
     assert step_text
-    messages.log("messages_step_executions: %s" % step_text, detail=VERBOSE)
-    if messages and step_text in messages.steps:
-        return messages.steps[step_text]["count"]
+    test_messages.log("messages_step_executions: %s" % step_text, detail=VERBOSE)
+    if offload_messages and step_text in offload_messages.steps:
+        return offload_messages.steps[step_text]["count"]
     return 0
 
 
-def get_offload_row_count_from_log(messages, test_name):
+def get_offload_row_count_from_log(offload_messages, test_messages):
     """Search test log forwards from the "test_name" we are processing and find the offload row count"""
-    messages.log("get_offload_row_count_from_log(%s)" % test_name, detail=VERBOSE)
-    matched_line = messages.get_line_from_log(
-        TOTAL_ROWS_OFFLOADED_LOG_TEXT, search_from_text=test_name
+    test_messages.log("get_offload_row_count_from_log()", detail=VERBOSE)
+    matched_line = test_functions.get_line_from_log(
+        offload_messages, TOTAL_ROWS_OFFLOADED_LOG_TEXT
     )
-    messages.log("matched_line: %s" % matched_line)
+    test_messages.log("matched_line: %s" % matched_line)
     rows = int(matched_line.split()[-1]) if matched_line else None
     return rows
 
@@ -425,11 +443,13 @@ def load_table_is_compressed(db_name, table_name, config, dfs_client, messages):
 
 
 def offload_rowsource_split_type_assertion(
-    messages: "OffloadMessages", story_id: str, split_type: str
+    offload_messages: "OffloadMessages",
+    split_type: str,
+    test_messages: "OffloadTestMessages",
 ):
     search = TRANSPORT_ROW_SOURCE_QUERY_SPLIT_TYPE_TEXT + split_type
-    if not text_in_log(messages, search, "(%s)" % (story_id)):
-        messages.log(
+    if not text_in_log(offload_messages, search, test_messages):
+        test_messages.log(
             f"offload_rowsource_split_type_assertion failed, did not find: {search}"
         )
         return False
@@ -474,17 +494,17 @@ def date_goe_part_column_name(backend_api, source_col_name, granularity_override
 def standard_dimension_assertion(
     config: "OrchestrationConfig",
     backend_api: "BackendTestingApiInterface",
-    messages: "OffloadMessages",
+    messages: "OffloadTestMessages",
     repo_client: "OrchestrationRepoClientInterface",
     schema: str,
     data_db: str,
     table_name: str,
     backend_db=None,
     backend_table=None,
-    story_id="",
     split_type=None,
     partition_functions=None,
     bucket_column=None,
+    offload_messages: "OffloadMessages" = None,
 ) -> bool:
     data_db = backend_db or data_db
     backend_table = backend_table or table_name
@@ -509,11 +529,15 @@ def standard_dimension_assertion(
         messages.log("backend_table_exists() == False")
         return False
 
-    if text_in_messages(messages, MISSING_ROWS_IMPORTED_WARNING):
+    if offload_messages and text_in_messages(
+        offload_messages, MISSING_ROWS_IMPORTED_WARNING, messages
+    ):
         return False
 
-    if split_type:
-        if not offload_rowsource_split_type_assertion(messages, story_id, split_type):
+    if split_type and offload_messages:
+        if not offload_rowsource_split_type_assertion(
+            offload_messages, split_type, messages
+        ):
             return False
 
     return True
@@ -523,7 +547,7 @@ def sales_based_fact_assertion(
     config: "OrchestrationConfig",
     backend_api: "BackendTestingApiInterface",
     frontend_api: "FrontendTestingApiInterface",
-    messages: "OffloadMessages",
+    messages: "OffloadTestMessages",
     repo_client: "OrchestrationRepoClientInterface",
     schema: str,
     data_db: str,
@@ -534,7 +558,6 @@ def sales_based_fact_assertion(
     offload_pattern=OFFLOAD_PATTERN_90_10,
     incremental_key="TIME_ID",
     incremental_range=None,
-    story_id="",
     split_type=None,
     check_hwm_in_metadata=True,
     ipa_predicate_type="RANGE",
@@ -543,6 +566,7 @@ def sales_based_fact_assertion(
     partition_functions=None,
     synthetic_partition_column_name=None,
     check_backend_rowcount=False,
+    offload_messages: "OffloadMessages" = None,
 ) -> bool:
     data_db = backend_db or data_db
     backend_table = backend_table or table_name
@@ -625,11 +649,15 @@ def sales_based_fact_assertion(
         ):
             return False
 
-    if text_in_messages(messages, MISSING_ROWS_IMPORTED_WARNING):
+    if offload_messages and text_in_messages(
+        offload_messages, MISSING_ROWS_IMPORTED_WARNING, messages
+    ):
         return False
 
-    if split_type:
-        if not offload_rowsource_split_type_assertion(messages, story_id, split_type):
+    if split_type and offload_messages:
+        if not offload_rowsource_split_type_assertion(
+            offload_messages, split_type, messages
+        ):
             return False
 
     return True

--- a/tests/integration/scenarios/scenario_runner.py
+++ b/tests/integration/scenarios/scenario_runner.py
@@ -65,10 +65,11 @@ def run_offload(
     execution_id = ExecutionId()
     messages = OffloadMessages.from_options(
         orchestration_config,
-        log_fh=parent_messages.get_log_fh(),
+        # log_fh=parent_messages.get_log_fh(),
         execution_id=execution_id,
         command_type=orchestration_constants.COMMAND_OFFLOAD,
     )
+    messages.init_log(orchestration_config.log_path, "test_offload")
     try:
         config_overrides = get_config_overrides(config_overrides, orchestration_config)
         messages_override = None if no_messages_override else messages
@@ -103,6 +104,12 @@ def run_offload(
         else:
             parent_messages.log(traceback.format_exc())
             raise
+    finally:
+        try:
+            messages.close_log()
+        except Exception:
+            pass
+
     return messages
 
 

--- a/tests/integration/scenarios/setup_functions.py
+++ b/tests/integration/scenarios/setup_functions.py
@@ -136,7 +136,7 @@ def get_sales_based_fact_partition_list(
     """
     if not frontend_api:
         return []
-    if type(hv_string_list) == str:
+    if isinstance(hv_string_list, str):
         hv_string_list = [hv_string_list]
 
     partitions = frontend_api.frontend_table_partition_list(

--- a/tests/integration/scenarios/test_column_controls.py
+++ b/tests/integration/scenarios/test_column_controls.py
@@ -501,6 +501,7 @@ def samp_date_assertion(
     backend_api,
     frontend_api,
     messages,
+    offload_messages,
     data_db,
     backend_name,
     from_stats=True,
@@ -573,7 +574,9 @@ def samp_date_assertion(
             % ("good_ts", expected_good_data_type)
         )
     if expected_bad_data_type != expected_good_data_type:
-        text_match = messages.text_in_messages(DATETIME_STATS_SAMPLING_OPT_ACTION_TEXT)
+        text_match = offload_messages.text_in_messages(
+            DATETIME_STATS_SAMPLING_OPT_ACTION_TEXT
+        )
         if text_match != from_stats:
             raise ScenarioRunnerException(
                 "text_match != from_stats: %s != %s" % (text_match, from_stats)
@@ -811,7 +814,7 @@ def test_numeric_controls(config, schema, data_db):
             "decimal_padding_digits": 2,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         nums_assertion(
             config,
             frontend_api,
@@ -835,8 +838,8 @@ def test_numeric_controls(config, schema, data_db):
                 "execute": True,
             }
             log_test_marker(messages, f"{id}:samp1")
-            run_offload(options, config, messages)
-            assert hint_text_in_log(messages, config, 0, f"{id}:samp1")
+            offload_messages = run_offload(options, config, messages)
+            assert hint_text_in_log(offload_messages, config, 0, f"{id}:samp1")
 
         # Offload Dimension With Parallel Sampling=3.
         # Runs with --no-verify to remove risk of verification having a PARALLEL hint.
@@ -850,8 +853,8 @@ def test_numeric_controls(config, schema, data_db):
                 "execute": True,
             }
             log_test_marker(messages, f"{id}:samp2")
-            run_offload(options, config, messages)
-            assert hint_text_in_log(messages, config, 3, f"{id}:samp2")
+            offload_messages = run_offload(options, config, messages)
+            assert hint_text_in_log(offload_messages, config, 3, f"{id}:samp2")
 
         # Offload Dimension with number overflow (expect to fail).
         if config.target not in [offload_constants.DBTYPE_BIGQUERY]:
@@ -1016,9 +1019,15 @@ def test_date_sampling(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         samp_date_assertion(
-            config, backend_api, frontend_api, messages, data_db, DATE_SDIM
+            config,
+            backend_api,
+            frontend_api,
+            messages,
+            offload_messages,
+            data_db,
+            DATE_SDIM,
         )
 
         # Remove stats from DATE_SDIM.
@@ -1042,12 +1051,13 @@ def test_date_sampling(config, schema, data_db):
             "reset_backend_table": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         samp_date_assertion(
             config,
             backend_api,
             frontend_api,
             messages,
+            offload_messages,
             data_db,
             DATE_SDIM,
             from_stats=False,
@@ -1076,12 +1086,13 @@ def test_date_sampling(config, schema, data_db):
             "reset_backend_table": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         samp_date_assertion(
             config,
             backend_api,
             frontend_api,
             messages,
+            offload_messages,
             data_db,
             DATE_SDIM,
             from_stats=False,

--- a/tests/integration/scenarios/test_column_controls.py
+++ b/tests/integration/scenarios/test_column_controls.py
@@ -41,7 +41,6 @@ from goe.offload.offload_functions import (
     data_db_name,
     load_db_name,
 )
-from goe.offload.offload_messages import VVERBOSE
 from goe.offload.offload_source_table import (
     DATA_SAMPLE_SIZE_AUTO,
     DATETIME_STATS_SAMPLING_OPT_ACTION_TEXT,

--- a/tests/integration/scenarios/test_column_controls.py
+++ b/tests/integration/scenarios/test_column_controls.py
@@ -60,6 +60,7 @@ from tests.integration.scenarios.assertion_functions import (
     backend_column_exists,
     frontend_column_exists,
     hint_text_in_log,
+    text_in_messages,
 )
 from tests.integration.scenarios.scenario_runner import (
     ScenarioRunnerException,
@@ -136,10 +137,6 @@ def load_db(schema, config):
     load_db = load_db_name(schema, config)
     load_db = convert_backend_identifier_case(config, load_db)
     return load_db
-
-
-def log_test_marker(messages, test_id):
-    messages.log(test_id, detail=VVERBOSE)
 
 
 def cast_validation_exception_text(backend_api):
@@ -574,8 +571,8 @@ def samp_date_assertion(
             % ("good_ts", expected_good_data_type)
         )
     if expected_bad_data_type != expected_good_data_type:
-        text_match = offload_messages.text_in_messages(
-            DATETIME_STATS_SAMPLING_OPT_ACTION_TEXT
+        text_match = text_in_messages(
+            offload_messages, DATETIME_STATS_SAMPLING_OPT_ACTION_TEXT, messages
         )
         if text_match != from_stats:
             raise ScenarioRunnerException(
@@ -837,9 +834,8 @@ def test_numeric_controls(config, schema, data_db):
                 "verify_row_count": False,
                 "execute": True,
             }
-            log_test_marker(messages, f"{id}:samp1")
             offload_messages = run_offload(options, config, messages)
-            assert hint_text_in_log(offload_messages, config, 0, f"{id}:samp1")
+            assert hint_text_in_log(offload_messages, config, 0)
 
         # Offload Dimension With Parallel Sampling=3.
         # Runs with --no-verify to remove risk of verification having a PARALLEL hint.
@@ -852,9 +848,8 @@ def test_numeric_controls(config, schema, data_db):
                 "verify_row_count": False,
                 "execute": True,
             }
-            log_test_marker(messages, f"{id}:samp2")
             offload_messages = run_offload(options, config, messages)
-            assert hint_text_in_log(offload_messages, config, 3, f"{id}:samp2")
+            assert hint_text_in_log(offload_messages, config, 3)
 
         # Offload Dimension with number overflow (expect to fail).
         if config.target not in [offload_constants.DBTYPE_BIGQUERY]:

--- a/tests/integration/scenarios/test_ddl_file.py
+++ b/tests/integration/scenarios/test_ddl_file.py
@@ -116,7 +116,7 @@ def new_table_ddl_file_tests(
         config, backend_api, messages, data_db, test_table
     ), f"Backend table for {schema}.{test_table} should not exist"
     assert text_in_messages(
-        offload_messages, offload_constants.DDL_FILE_EXECUTE_MESSAGE_TEXT
+        offload_messages, offload_constants.DDL_FILE_EXECUTE_MESSAGE_TEXT, messages
     )
     step_assertions(offload_messages)
 
@@ -179,7 +179,7 @@ def exsting_table_ddl_file_tests(
         config, backend_api, messages, data_db, test_table
     ), f"Backend table for {schema}.{test_table} should exist"
     assert text_in_messages(
-        offload_messages, offload_constants.DDL_FILE_EXECUTE_MESSAGE_TEXT
+        offload_messages, offload_constants.DDL_FILE_EXECUTE_MESSAGE_TEXT, messages
     )
     step_assertions(offload_messages)
     assert os.path.isfile(ddl_file), f"DDL file has not been created: {ddl_file}"

--- a/tests/integration/scenarios/test_identifiers.py
+++ b/tests/integration/scenarios/test_identifiers.py
@@ -24,7 +24,6 @@ from goe.offload.offload_functions import (
     convert_backend_identifier_case,
     data_db_name,
 )
-from goe.offload.offload_messages import VVERBOSE
 from goe.offload.offload_transport import (
     OFFLOAD_TRANSPORT_METHOD_QUERY_IMPORT,
     OFFLOAD_TRANSPORT_METHOD_SPARK_DATAPROC_GCLOUD,

--- a/tests/integration/scenarios/test_identifiers.py
+++ b/tests/integration/scenarios/test_identifiers.py
@@ -123,10 +123,6 @@ def backend_case_offload_assertion(
     return result
 
 
-def log_test_marker(messages, test_id):
-    messages.log(test_id, detail=VVERBOSE)
-
-
 def test_identifiers_keyword_column_names(config, schema, data_db):
     id = "test_identifiers_keyword_column_names"
     with get_test_messages_ctx(config, id) as messages, get_frontend_testing_api_ctx(

--- a/tests/integration/scenarios/test_offload_backend_part_dates.py
+++ b/tests/integration/scenarios/test_offload_backend_part_dates.py
@@ -189,7 +189,7 @@ def fact_as_date_tests(
         "create_backend_db": True,
         "execute": True,
     }
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
 
     assert sales_based_fact_assertion(
         config,
@@ -202,6 +202,7 @@ def fact_as_date_tests(
         table_name,
         test_constants.SALES_BASED_FACT_HV_2,
         check_backend_rowcount=True,
+        offload_messages=offload_messages,
     )
     assert offload_date_assertion(
         config,
@@ -456,7 +457,7 @@ def test_offload_backend_part_date_as_str(config, schema, data_db):
             "reset_backend_table": True,
             "execute": True,
         }
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
@@ -477,6 +478,7 @@ def test_offload_backend_part_date_as_str(config, schema, data_db):
                 test_constants.SALES_BASED_FACT_HV_1,
                 check_backend_rowcount=True,
                 offload_pattern=scenario_constants.OFFLOAD_PATTERN_90_10,
+                offload_messages=offload_messages,
             )
             assert backend_column_exists(
                 backend_api,

--- a/tests/integration/scenarios/test_offload_data.py
+++ b/tests/integration/scenarios/test_offload_data.py
@@ -178,7 +178,7 @@ def gen_fractional_second_partition_table_ddl(
 
 
 def gen_offload_nulls_create_ddl(
-    schema, table_name, backend_api, frontend_api, config, to_allow_query_import
+    schema, table_name, backend_api, frontend_api, config, to_allow_query_import=False
 ):
     ddl = ["DROP TABLE %(schema)s.%(table)s" % {"schema": schema, "table": table_name}]
     if config.db_type == offload_constants.DBTYPE_ORACLE:

--- a/tests/integration/scenarios/test_offload_data.py
+++ b/tests/integration/scenarios/test_offload_data.py
@@ -505,7 +505,7 @@ def test_offload_data_partition_by_microsecond(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -519,6 +519,7 @@ def test_offload_data_partition_by_microsecond(config, schema, data_db):
             incremental_key="TS",
             incremental_key_type=frontend_datetime,
             check_backend_rowcount=True,
+            offload_messages=offload_messages,
         )
 
         # Offload second partition from a microsecond partitioned table.
@@ -532,7 +533,7 @@ def test_offload_data_partition_by_microsecond(config, schema, data_db):
             ),
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -546,6 +547,7 @@ def test_offload_data_partition_by_microsecond(config, schema, data_db):
             incremental_key="TS",
             incremental_key_type=frontend_datetime,
             check_backend_rowcount=True,
+            offload_messages=offload_messages,
         )
 
         # No-op offload of microsecond partitioned table.
@@ -618,7 +620,7 @@ def test_offload_data_partition_by_nanosecond(config, schema, data_db):
                 "create_backend_db": True,
                 "execute": True,
             }
-            run_offload(options, config, messages)
+            offload_messages = run_offload(options, config, messages)
             assert sales_based_fact_assertion(
                 config,
                 backend_api,
@@ -631,6 +633,7 @@ def test_offload_data_partition_by_nanosecond(config, schema, data_db):
                 "2030-01-02",
                 incremental_key="TS",
                 incremental_key_type=frontend_datetime,
+                offload_messages=offload_messages,
             )
 
             # Offload second partition from a nanosecond partitioned table.
@@ -645,7 +648,7 @@ def test_offload_data_partition_by_nanosecond(config, schema, data_db):
                 ),
                 "execute": True,
             }
-            run_offload(options, config, messages)
+            offload_messages = run_offload(options, config, messages)
             assert sales_based_fact_assertion(
                 config,
                 backend_api,
@@ -658,6 +661,7 @@ def test_offload_data_partition_by_nanosecond(config, schema, data_db):
                 "2030-01-02",
                 incremental_key="TS",
                 incremental_key_type=frontend_datetime,
+                offload_messages=offload_messages,
             )
 
 
@@ -1009,7 +1013,7 @@ def test_offload_data_large_decimals_rpa(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -1026,6 +1030,7 @@ def test_offload_data_large_decimals_rpa(config, schema, data_db):
             ),
             offload_pattern=scenario_constants.OFFLOAD_PATTERN_90_10,
             incremental_key="part_col",
+            offload_messages=offload_messages,
         )
 
         # Offload 2nd partition.
@@ -1036,7 +1041,7 @@ def test_offload_data_large_decimals_rpa(config, schema, data_db):
             "offload_transport_method": no_query_import_transport_method(config),
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -1049,6 +1054,7 @@ def test_offload_data_large_decimals_rpa(config, schema, data_db):
             gen_large_num_list_part_literal(backend_api),
             offload_pattern=scenario_constants.OFFLOAD_PATTERN_90_10,
             incremental_key="part_col",
+            offload_messages=offload_messages,
         )
 
         # Offload 3rd partition, HWM all 9s.
@@ -1058,7 +1064,7 @@ def test_offload_data_large_decimals_rpa(config, schema, data_db):
             "offload_transport_method": no_query_import_transport_method(config),
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -1071,4 +1077,5 @@ def test_offload_data_large_decimals_rpa(config, schema, data_db):
             gen_large_num_list_part_literal(backend_api, all_nines=True),
             offload_pattern=scenario_constants.OFFLOAD_PATTERN_90_10,
             incremental_key="part_col",
+            offload_messages=offload_messages,
         )

--- a/tests/integration/scenarios/test_offload_hash_column.py
+++ b/tests/integration/scenarios/test_offload_hash_column.py
@@ -23,9 +23,7 @@ from goe.persistence.factory.orchestration_repo_client_factory import (
     orchestration_repo_client_factory,
 )
 
-from tests.integration.scenarios.assertion_functions import (
-    standard_dimension_assertion,
-)
+from tests.integration.scenarios.assertion_functions import standard_dimension_assertion
 from tests.integration.scenarios.scenario_runner import (
     run_offload,
     run_setup,
@@ -116,7 +114,7 @@ def test_offload_hash_column_synapse(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
@@ -131,6 +129,7 @@ def test_offload_hash_column_synapse(config, schema, data_db):
             data_db,
             OFFLOAD_DIM,
             bucket_column="NULL",
+            offload_messages=offload_messages,
         )
         assert synapse_distribution_assertion(
             backend_api, messages, data_db, OFFLOAD_DIM, "ROUND_ROBIN"
@@ -143,7 +142,7 @@ def test_offload_hash_column_synapse(config, schema, data_db):
             "reset_backend_table": True,
             "execute": True,
         }
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
@@ -158,6 +157,7 @@ def test_offload_hash_column_synapse(config, schema, data_db):
             data_db,
             OFFLOAD_DIM,
             bucket_column="PROD_ID",
+            offload_messages=offload_messages,
         )
         assert synapse_distribution_assertion(
             backend_api, messages, data_db, OFFLOAD_DIM, "HASH"
@@ -169,7 +169,7 @@ def test_offload_hash_column_synapse(config, schema, data_db):
             "reset_backend_table": True,
             "execute": True,
         }
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
@@ -184,6 +184,7 @@ def test_offload_hash_column_synapse(config, schema, data_db):
             data_db,
             OFFLOAD_DIM,
             bucket_column="PROD_ID",
+            offload_messages=offload_messages,
         )
         assert synapse_distribution_assertion(
             backend_api, messages, data_db, OFFLOAD_DIM, "HASH"

--- a/tests/integration/scenarios/test_offload_list_rpa.py
+++ b/tests/integration/scenarios/test_offload_list_rpa.py
@@ -177,7 +177,7 @@ def offload_list_as_range_ipa_standard_story_tests(
         "create_backend_db": True,
         "execute": True,
     }
-    run_offload(
+    offload_messages = run_offload(
         options,
         config,
         messages,
@@ -198,6 +198,7 @@ def offload_list_as_range_ipa_standard_story_tests(
         backend_table=backend_name,
         partition_functions=udf,
         synthetic_partition_column_name=gl_part_column_check_name,
+        offload_messages=offload_messages,
     )
 
     # 2nd partition happens to be empty but we should still move HWMs etc.
@@ -206,7 +207,7 @@ def offload_list_as_range_ipa_standard_story_tests(
         less_than_option: hv_3,
         "execute": True,
     }
-    run_offload(
+    offload_messages = run_offload(
         options,
         config,
         messages,
@@ -226,6 +227,7 @@ def offload_list_as_range_ipa_standard_story_tests(
         incremental_key_type=part_key_type,
         partition_functions=udf,
         synthetic_partition_column_name=gl_part_column_check_name,
+        offload_messages=offload_messages,
     )
 
     # Attempt to top up LIST_AS_RANGE by LPA - expect exception.
@@ -262,7 +264,7 @@ def offload_list_as_range_ipa_standard_story_tests(
         "partition_names_csv": test_constants.SALES_BASED_LIST_PNAME_4,
         "execute": True,
     }
-    run_offload(
+    offload_messages = run_offload(
         options,
         config,
         messages,
@@ -281,6 +283,7 @@ def offload_list_as_range_ipa_standard_story_tests(
         ipa_predicate_type=INCREMENTAL_PREDICATE_TYPE_LIST_AS_RANGE,
         incremental_key_type=part_key_type,
         partition_functions=udf,
+        offload_messages=offload_messages,
     )
 
     # No-op re-offload of 3rd partition.
@@ -320,7 +323,7 @@ def offload_list_as_range_ipa_standard_story_tests(
         less_than_option: hv_5,
         "execute": True,
     }
-    run_offload(
+    offload_messages = run_offload(
         options,
         config,
         messages,
@@ -339,6 +342,7 @@ def offload_list_as_range_ipa_standard_story_tests(
         ipa_predicate_type=INCREMENTAL_PREDICATE_TYPE_LIST_AS_RANGE,
         incremental_key_type=part_key_type,
         partition_functions=udf,
+        offload_messages=offload_messages,
     )
 
 
@@ -582,7 +586,7 @@ def test_offload_list_rpa_subpart(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
@@ -601,4 +605,5 @@ def test_offload_list_rpa_subpart(config, schema, data_db):
             ipa_predicate_type=INCREMENTAL_PREDICATE_TYPE_LIST_AS_RANGE,
             incremental_key_type=ORACLE_TYPE_NUMBER,
             incremental_range="PARTITION",
+            offload_messages=offload_messages,
         )

--- a/tests/integration/scenarios/test_offload_misc.py
+++ b/tests/integration/scenarios/test_offload_misc.py
@@ -194,7 +194,7 @@ def test_offload_misc_maxvalue_partition(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -206,6 +206,7 @@ def test_offload_misc_maxvalue_partition(config, schema, data_db):
             MAXVAL_FACT,
             test_constants.SALES_BASED_FACT_HV_2,
             offload_pattern=scenario_constants.OFFLOAD_PATTERN_90_10,
+            offload_messages=offload_messages,
         )
 
         # 90/10 Offload of Fact with MAXVALUE Partition.
@@ -226,8 +227,11 @@ def test_offload_misc_maxvalue_partition(config, schema, data_db):
             MAXVAL_FACT,
             test_constants.SALES_BASED_FACT_HV_6,
             offload_pattern=scenario_constants.OFFLOAD_PATTERN_90_10,
+            offload_messages=offload_messages,
         )
-        assert text_in_messages(offload_messages, NO_MAXVALUE_PARTITION_NOTICE_TEXT)
+        assert text_in_messages(
+            offload_messages, NO_MAXVALUE_PARTITION_NOTICE_TEXT, messages
+        )
 
         # Offload 90/10 fact to 100/0.
         # Offloads all partitions from a fact table including MAXVALUE partition.
@@ -249,4 +253,5 @@ def test_offload_misc_maxvalue_partition(config, schema, data_db):
             None,
             offload_pattern=scenario_constants.OFFLOAD_PATTERN_100_0,
             check_backend_rowcount=True,
+            offload_messages=offload_messages,
         )

--- a/tests/integration/scenarios/test_offload_misc.py
+++ b/tests/integration/scenarios/test_offload_misc.py
@@ -72,10 +72,6 @@ def data_db(schema, config):
     return data_db
 
 
-def log_test_marker(messages, test_id):
-    messages.log(test_id, detail=VVERBOSE)
-
-
 def test_offload_misc_verification_parallel(config, schema, data_db):
     id = "test_offload_misc_verification_parallel"
 
@@ -112,9 +108,8 @@ def test_offload_misc_verification_parallel(config, schema, data_db):
             "reset_backend_table": True,
             "execute": False,
         }
-        log_test_marker(messages, f"{id}1")
-        run_offload(options, config, messages)
-        assert hint_text_in_log(messages, config, 3, f"{id}1")
+        offload_messages = run_offload(options, config, messages)
+        assert hint_text_in_log(offload_messages, config, 3)
 
         # Offload with verification parallelism=1.
         options = {
@@ -124,9 +119,8 @@ def test_offload_misc_verification_parallel(config, schema, data_db):
             "reset_backend_table": True,
             "execute": False,
         }
-        log_test_marker(messages, f"{id}2")
-        run_offload(options, config, messages)
-        assert hint_text_in_log(messages, config, 1, f"{id}2")
+        offload_messages = run_offload(options, config, messages)
+        assert hint_text_in_log(offload_messages, config, 1)
 
         # Offload with verification parallelism=0.
         options = {
@@ -136,9 +130,8 @@ def test_offload_misc_verification_parallel(config, schema, data_db):
             "reset_backend_table": True,
             "execute": False,
         }
-        log_test_marker(messages, f"{id}3")
-        run_offload(options, config, messages)
-        assert hint_text_in_log(messages, config, 0, f"{id}3")
+        offload_messages = run_offload(options, config, messages)
+        assert hint_text_in_log(offload_messages, config, 0)
 
         # Offload with aggregation verification parallelism=4.
         options = {
@@ -150,9 +143,8 @@ def test_offload_misc_verification_parallel(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        log_test_marker(messages, f"{id}4")
-        run_offload(options, config, messages)
-        assert hint_text_in_log(messages, config, 4, f"{id}4")
+        offload_messages = run_offload(options, config, messages)
+        assert hint_text_in_log(offload_messages, config, 4)
 
 
 def test_offload_misc_maxvalue_partition(config, schema, data_db):

--- a/tests/integration/scenarios/test_offload_part_fn.py
+++ b/tests/integration/scenarios/test_offload_part_fn.py
@@ -361,7 +361,7 @@ def test_offload_part_fn_num(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert standard_dimension_assertion(
             config,
             backend_api,
@@ -373,6 +373,7 @@ def test_offload_part_fn_num(config, schema, data_db):
             partition_functions=expected_udf_metadata(
                 config, data_db, data_db + "." + INT8_UDF
             ),
+            offload_messages=offload_messages,
         )
         assert offload_part_fn_assertion(
             config, backend_api, messages, data_db, DIM_NUM, udf=INT8_UDF
@@ -390,7 +391,7 @@ def test_offload_part_fn_num(config, schema, data_db):
             "reset_backend_table": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert standard_dimension_assertion(
             config,
             backend_api,
@@ -400,6 +401,7 @@ def test_offload_part_fn_num(config, schema, data_db):
             data_db,
             DIM_NUM,
             partition_functions=expected_udf_metadata(config, data_db, INT8_UDF),
+            offload_messages=offload_messages,
         )
         assert offload_part_fn_assertion(
             config, backend_api, messages, data_db, DIM_NUM, udf=INT8_UDF
@@ -450,7 +452,7 @@ def test_offload_part_fn_dec(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert standard_dimension_assertion(
             config,
             backend_api,
@@ -460,6 +462,7 @@ def test_offload_part_fn_dec(config, schema, data_db):
             data_db,
             DIM_DEC,
             partition_functions=expected_udf_metadata(config, data_db, INT38_UDF),
+            offload_messages=offload_messages,
         )
         assert offload_part_fn_assertion(
             config, backend_api, messages, data_db, DIM_DEC, udf=INT38_UDF
@@ -478,7 +481,7 @@ def test_offload_part_fn_dec(config, schema, data_db):
             "reset_backend_table": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert standard_dimension_assertion(
             config,
             backend_api,
@@ -488,6 +491,7 @@ def test_offload_part_fn_dec(config, schema, data_db):
             data_db,
             DIM_DEC,
             partition_functions=expected_udf_metadata(config, data_db, DEC19_UDF),
+            offload_messages=offload_messages,
         )
         assert offload_part_fn_assertion(
             config, backend_api, messages, data_db, DIM_DEC, udf=DEC19_UDF
@@ -541,7 +545,7 @@ def test_offload_part_fn_str(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert standard_dimension_assertion(
             config,
             backend_api,
@@ -551,6 +555,7 @@ def test_offload_part_fn_str(config, schema, data_db):
             data_db,
             DIM_STR,
             partition_functions=expected_udf_metadata(config, data_db, STRING_UDF),
+            offload_messages=offload_messages,
         )
         assert offload_part_fn_assertion(
             config,

--- a/tests/integration/scenarios/test_offload_pbo.py
+++ b/tests/integration/scenarios/test_offload_pbo.py
@@ -227,16 +227,22 @@ def check_pbo_metadata(
 
 
 def check_predicate_count_matches_log(
-    frontend_api, messages, schema, table_name, test_id, where_clause
+    frontend_api,
+    test_messages,
+    offload_messages,
+    schema,
+    table_name,
+    test_id,
+    where_clause,
 ):
     """Compare RDBMS count to logged count."""
-    messages.log("check_predicate_count_matches_log(%s)" % test_id)
+    test_messages.log("check_predicate_count_matches_log(%s)" % test_id)
     app_count = frontend_api.get_table_row_count(
         schema, table_name, filter_clause=where_clause
     )
-    offload_count = get_offload_row_count_from_log(messages, test_id)
+    offload_count = get_offload_row_count_from_log(offload_messages, test_messages)
     if app_count != offload_count:
-        messages.log("%s != %s" % (app_count, offload_count))
+        test_messages.log("%s != %s" % (app_count, offload_count))
         return False
     return True
 
@@ -437,13 +443,20 @@ def test_offload_pbo_dim(config, schema, data_db):
             "execute": True,
         }
         messages.log(f"{id}:1", detail=VVERBOSE)
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
         )
         assert standard_dimension_assertion(
-            config, backend_api, messages, repo_client, schema, data_db, DIM_TABLE
+            config,
+            backend_api,
+            messages,
+            repo_client,
+            schema,
+            data_db,
+            DIM_TABLE,
+            offload_messages=offload_messages,
         )
         assert pbo_assertion(
             messages,
@@ -460,6 +473,7 @@ def test_offload_pbo_dim(config, schema, data_db):
         assert check_predicate_count_matches_log(
             frontend_api,
             messages,
+            offload_messages,
             schema,
             DIM_TABLE,
             f"{id}:1",
@@ -543,7 +557,7 @@ def test_offload_pbo_dim(config, schema, data_db):
             "execute": True,
         }
         messages.log(f"{id}:2", detail=VVERBOSE)
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
@@ -567,6 +581,7 @@ def test_offload_pbo_dim(config, schema, data_db):
         assert check_predicate_count_matches_log(
             frontend_api,
             messages,
+            offload_messages,
             schema,
             DIM_TABLE,
             f"{id}:2",
@@ -614,13 +629,20 @@ def test_offload_pbo_unicode(config, schema, data_db):
             "execute": True,
         }
         messages.log(f"{id}:1", detail=VVERBOSE)
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
         )
         assert standard_dimension_assertion(
-            config, backend_api, messages, repo_client, schema, data_db, UNICODE_TABLE
+            config,
+            backend_api,
+            messages,
+            repo_client,
+            schema,
+            data_db,
+            UNICODE_TABLE,
+            offload_messages=offload_messages,
         )
         assert pbo_assertion(
             messages,
@@ -633,6 +655,7 @@ def test_offload_pbo_unicode(config, schema, data_db):
         assert check_predicate_count_matches_log(
             frontend_api,
             messages,
+            offload_messages,
             schema,
             UNICODE_TABLE,
             f"{id}:1",
@@ -648,13 +671,20 @@ def test_offload_pbo_unicode(config, schema, data_db):
             "execute": True,
         }
         messages.log(f"{id}:2", detail=VVERBOSE)
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
         )
         assert standard_dimension_assertion(
-            config, backend_api, messages, repo_client, schema, data_db, UNICODE_TABLE
+            config,
+            backend_api,
+            messages,
+            repo_client,
+            schema,
+            data_db,
+            UNICODE_TABLE,
+            offload_messages=offload_messages,
         )
         assert pbo_assertion(
             messages,
@@ -667,6 +697,7 @@ def test_offload_pbo_unicode(config, schema, data_db):
         assert check_predicate_count_matches_log(
             frontend_api,
             messages,
+            offload_messages,
             schema,
             UNICODE_TABLE,
             f"{id}:2",
@@ -710,13 +741,20 @@ def test_offload_pbo_char_pad(config, schema, data_db):
             "execute": True,
         }
         messages.log(f"{id}:1", detail=VVERBOSE)
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
         )
         assert standard_dimension_assertion(
-            config, backend_api, messages, repo_client, schema, data_db, CHAR_TABLE
+            config,
+            backend_api,
+            messages,
+            repo_client,
+            schema,
+            data_db,
+            CHAR_TABLE,
+            offload_messages=offload_messages,
         )
         assert pbo_assertion(
             messages,
@@ -729,6 +767,7 @@ def test_offload_pbo_char_pad(config, schema, data_db):
         assert check_predicate_count_matches_log(
             frontend_api,
             messages,
+            offload_messages,
             schema,
             CHAR_TABLE,
             f"{id}:1",
@@ -786,13 +825,20 @@ def test_offload_pbo_ts(config, schema, data_db):
             "execute": True,
         }
         messages.log(f"{id}:1", detail=VVERBOSE)
-        run_offload(
+        offload_messages = run_offload(
             options,
             config,
             messages,
         )
         assert standard_dimension_assertion(
-            config, backend_api, messages, repo_client, schema, data_db, TS_TABLE
+            config,
+            backend_api,
+            messages,
+            repo_client,
+            schema,
+            data_db,
+            TS_TABLE,
+            offload_messages=offload_messages,
         )
         assert pbo_assertion(
             messages,
@@ -805,6 +851,7 @@ def test_offload_pbo_ts(config, schema, data_db):
         assert check_predicate_count_matches_log(
             frontend_api,
             messages,
+            offload_messages,
             schema,
             TS_TABLE,
             f"{id}:1",
@@ -873,7 +920,7 @@ def test_offload_pbo_range(config, schema, data_db):
             "execute": True,
         }
         messages.log(f"{id}:1", detail=VVERBOSE)
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert pbo_assertion(
             messages,
             repo_client,
@@ -892,6 +939,7 @@ def test_offload_pbo_range(config, schema, data_db):
         assert check_predicate_count_matches_log(
             frontend_api,
             messages,
+            offload_messages,
             schema,
             RANGE_TABLE,
             f"{id}:1",
@@ -1032,7 +1080,7 @@ def test_offload_pbo_list(config, schema, data_db):
             "execute": True,
         }
         messages.log(f"{id}:1", detail=VVERBOSE)
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert pbo_assertion(
             messages,
             repo_client,
@@ -1051,6 +1099,7 @@ def test_offload_pbo_list(config, schema, data_db):
         assert check_predicate_count_matches_log(
             frontend_api,
             messages,
+            offload_messages,
             schema,
             LIST_TABLE,
             f"{id}:1",
@@ -1081,7 +1130,7 @@ def test_offload_pbo_list(config, schema, data_db):
             "execute": True,
         }
         messages.log(f"{id}:2", detail=VVERBOSE)
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert pbo_assertion(
             messages,
             repo_client,
@@ -1100,6 +1149,7 @@ def test_offload_pbo_list(config, schema, data_db):
         assert check_predicate_count_matches_log(
             frontend_api,
             messages,
+            offload_messages,
             schema,
             LIST_TABLE,
             f"{id}:2",

--- a/tests/integration/scenarios/test_offload_pbo.py
+++ b/tests/integration/scenarios/test_offload_pbo.py
@@ -476,7 +476,7 @@ def test_offload_pbo_dim(config, schema, data_db):
             offload_messages,
             schema,
             DIM_TABLE,
-            f"{id}:1",
+            id,
             "txn_desc = 'ABC'",
         )
 
@@ -584,7 +584,7 @@ def test_offload_pbo_dim(config, schema, data_db):
             offload_messages,
             schema,
             DIM_TABLE,
-            f"{id}:2",
+            id,
             "txn_desc = 'GHI'",
         )
 
@@ -658,7 +658,7 @@ def test_offload_pbo_unicode(config, schema, data_db):
             offload_messages,
             schema,
             UNICODE_TABLE,
-            f"{id}:1",
+            id,
             "data = '%s'" % UCODE_VALUE1,
         )
 
@@ -700,7 +700,7 @@ def test_offload_pbo_unicode(config, schema, data_db):
             offload_messages,
             schema,
             UNICODE_TABLE,
-            f"{id}:2",
+            id,
             "data = '%s'" % UCODE_VALUE2,
         )
 
@@ -770,7 +770,7 @@ def test_offload_pbo_char_pad(config, schema, data_db):
             offload_messages,
             schema,
             CHAR_TABLE,
-            f"{id}:1",
+            id,
             "data = 'a  '",
         )
 
@@ -854,7 +854,7 @@ def test_offload_pbo_ts(config, schema, data_db):
             offload_messages,
             schema,
             TS_TABLE,
-            f"{id}:1",
+            id,
             "id = 1",
         )
 
@@ -942,7 +942,7 @@ def test_offload_pbo_range(config, schema, data_db):
             offload_messages,
             schema,
             RANGE_TABLE,
-            f"{id}:1",
+            id,
             "time_id >= %s and time_id < %s"
             % (
                 const_to_date_expr(config, test_constants.SALES_BASED_FACT_HV_2),
@@ -1102,7 +1102,7 @@ def test_offload_pbo_list(config, schema, data_db):
             offload_messages,
             schema,
             LIST_TABLE,
-            f"{id}:1",
+            id,
             "yrmon = %s AND channel_id = 3"
             % const_to_date_expr(config, test_constants.SALES_BASED_FACT_HV_1),
         )
@@ -1152,7 +1152,7 @@ def test_offload_pbo_list(config, schema, data_db):
             offload_messages,
             schema,
             LIST_TABLE,
-            f"{id}:2",
+            id,
             "yrmon = %s AND channel_id = 4"
             % const_to_date_expr(config, test_constants.SALES_BASED_FACT_HV_1),
         )

--- a/tests/integration/scenarios/test_offload_pbo_intra.py
+++ b/tests/integration/scenarios/test_offload_pbo_intra.py
@@ -161,7 +161,7 @@ def offload_pbo_intra_day_std_range_tests(
         "reset_backend_table": True,
         "execute": True,
     }
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
         backend_api,
@@ -176,6 +176,7 @@ def offload_pbo_intra_day_std_range_tests(
         incremental_key_type=part_key_type,
         incremental_predicate_value="NULL",
         ipa_predicate_type=ipa_predicate_type,
+        offload_messages=offload_messages,
     )
 
     # Attempts to use a predicate without supplying the partition column which is invalid.
@@ -227,7 +228,7 @@ def offload_pbo_intra_day_std_range_tests(
         "execute": True,
     }
     messages.log(f"{test_id}:1", detail=VVERBOSE)
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
         backend_api,
@@ -241,6 +242,7 @@ def offload_pbo_intra_day_std_range_tests(
         incremental_key=inc_key,
         incremental_key_type=part_key_type,
         ipa_predicate_type=ipa_predicate_type,
+        offload_messages=offload_messages,
     )
     assert pbo_assertion(
         messages,
@@ -255,6 +257,7 @@ def offload_pbo_intra_day_std_range_tests(
     assert check_predicate_count_matches_log(
         frontend_api,
         messages,
+        offload_messages,
         schema,
         table_name,
         f"{test_id}:1",
@@ -285,7 +288,7 @@ def offload_pbo_intra_day_std_range_tests(
         "execute": True,
     }
     messages.log(f"{test_id}:2", detail=VVERBOSE)
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
         backend_api,
@@ -299,6 +302,7 @@ def offload_pbo_intra_day_std_range_tests(
         incremental_key=inc_key,
         incremental_key_type=part_key_type,
         ipa_predicate_type=ipa_predicate_type,
+        offload_messages=offload_messages,
     )
     assert pbo_assertion(
         messages,
@@ -312,6 +316,7 @@ def offload_pbo_intra_day_std_range_tests(
     assert check_predicate_count_matches_log(
         frontend_api,
         messages,
+        offload_messages,
         schema,
         table_name,
         f"{test_id}:2",
@@ -326,7 +331,7 @@ def offload_pbo_intra_day_std_range_tests(
         "execute": True,
     }
     messages.log(f"{test_id}:3", detail=VVERBOSE)
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
         backend_api,
@@ -340,6 +345,7 @@ def offload_pbo_intra_day_std_range_tests(
         incremental_key=inc_key,
         incremental_key_type=part_key_type,
         ipa_predicate_type=ipa_predicate_type,
+        offload_messages=offload_messages,
     )
     assert pbo_assertion(
         messages,
@@ -353,6 +359,7 @@ def offload_pbo_intra_day_std_range_tests(
     assert check_predicate_count_matches_log(
         frontend_api,
         messages,
+        offload_messages,
         schema,
         table_name,
         f"{test_id}:3",
@@ -368,7 +375,7 @@ def offload_pbo_intra_day_std_range_tests(
         "execute": True,
     }
     messages.log(f"{test_id}:4", detail=VVERBOSE)
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
         backend_api,
@@ -383,6 +390,7 @@ def offload_pbo_intra_day_std_range_tests(
         incremental_key_type=part_key_type,
         ipa_predicate_type=ipa_predicate_type,
         check_backend_rowcount=False,
+        offload_messages=offload_messages,
     )
     assert pbo_assertion(
         messages,
@@ -396,6 +404,7 @@ def offload_pbo_intra_day_std_range_tests(
     assert check_predicate_count_matches_log(
         frontend_api,
         messages,
+        offload_messages,
         schema,
         table_name,
         f"{test_id}:4",

--- a/tests/integration/scenarios/test_offload_pbo_late.py
+++ b/tests/integration/scenarios/test_offload_pbo_late.py
@@ -178,7 +178,7 @@ def offload_pbo_late_100_x_tests(
         "create_backend_db": True,
         "execute": True,
     }
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
         backend_api,
@@ -193,6 +193,7 @@ def offload_pbo_late_100_x_tests(
         incremental_key=inc_key,
         incremental_key_type=part_key_type,
         ipa_predicate_type=ipa_predicate_type,
+        offload_messages=offload_messages,
     )
 
     # Add late arriving data below the HWM.
@@ -240,7 +241,7 @@ def offload_pbo_late_100_x_tests(
         "execute": True,
     }
     messages.log(f"{test_id}:1", detail=VVERBOSE)
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
         backend_api,
@@ -256,13 +257,14 @@ def offload_pbo_late_100_x_tests(
         incremental_key_type=part_key_type,
         ipa_predicate_type=ipa_predicate_type,
         incremental_predicate_value="NULL",
+        offload_messages=offload_messages,
     )
     assert check_predicate_count_matches_log(
         frontend_api,
         messages,
+        offload_messages,
         schema,
         table_name,
-        f"{test_id}:1",
         "time_id = %s" % const_to_date_expr(config, OLD_HV_1),
     )
 
@@ -354,7 +356,7 @@ def offload_pbo_late_arriving_std_range_tests(
         "create_backend_db": True,
         "execute": True,
     }
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
         backend_api,
@@ -371,6 +373,7 @@ def offload_pbo_late_arriving_std_range_tests(
         incremental_predicate_value="NULL",
         incremental_range=expected_incremental_range,
         check_hwm_in_metadata=check_hwm_in_metadata,
+        offload_messages=offload_messages,
     )
 
     # No-op Offload Late Arriving Data.
@@ -466,7 +469,7 @@ def offload_pbo_late_arriving_std_range_tests(
         "execute": True,
     }
     messages.log(f"{test_id}:1", detail=VVERBOSE)
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
         backend_api,
@@ -482,13 +485,17 @@ def offload_pbo_late_arriving_std_range_tests(
         ipa_predicate_type=ipa_predicate_type,
         incremental_predicate_value="NULL",
         check_hwm_in_metadata=check_hwm_in_metadata,
+        offload_messages=offload_messages,
     )
     assert check_predicate_count_matches_log(
-        frontend_api, messages, schema, table_name, f"{test_id}:1", chk_cnt_filter
+        frontend_api,
+        messages,
+        offload_messages,
+        schema,
+        table_name,
+        chk_cnt_filter,
     )
-    assert text_in_log(
-        messages, PREDICATE_APPEND_HWM_MESSAGE_TEXT, search_from_text=f"{test_id}:1"
-    )
+    assert text_in_log(offload_messages, PREDICATE_APPEND_HWM_MESSAGE_TEXT, messages)
 
     # Attempt to re-offload same predicate.
     run_offload(options, config, messages, expected_status=False)

--- a/tests/integration/scenarios/test_offload_pbo_late.py
+++ b/tests/integration/scenarios/test_offload_pbo_late.py
@@ -24,7 +24,6 @@ from goe.offload.offload_functions import (
     convert_backend_identifier_case,
     data_db_name,
 )
-from goe.offload.offload_messages import VVERBOSE
 from goe.offload.offload_metadata_functions import (
     OFFLOAD_TYPE_FULL,
     OFFLOAD_TYPE_INCREMENTAL,
@@ -138,9 +137,12 @@ def offload_pbo_late_100_x_tests(
     if table_name == RANGE_TABLE_LATE_100_0:
         inc_key = "TIME_ID"
         ipa_predicate_type = INCREMENTAL_PREDICATE_TYPE_RANGE
-        add_rows_fn = lambda: frontend_api.sales_based_fact_late_arriving_data_sql(
-            schema, table_name, OLD_HV_1
-        )
+
+        def add_rows_fn():
+            return frontend_api.sales_based_fact_late_arriving_data_sql(
+                schema, table_name, OLD_HV_1
+            )
+
         if offload_pattern == OFFLOAD_PATTERN_100_0:
             test_id = "range_100_0"
             hv_1 = chk_hv_1 = None
@@ -155,9 +157,12 @@ def offload_pbo_late_100_x_tests(
             return []
         inc_key = "YRMON"
         ipa_predicate_type = INCREMENTAL_PREDICATE_TYPE_LIST_AS_RANGE
-        add_rows_fn = lambda: frontend_api.sales_based_list_fact_late_arriving_data_sql(
-            schema, table_name, OLD_HV_1, test_constants.SALES_BASED_FACT_HV_1
-        )
+
+        def add_rows_fn():
+            return frontend_api.sales_based_list_fact_late_arriving_data_sql(
+                schema, table_name, OLD_HV_1, test_constants.SALES_BASED_FACT_HV_1
+            )
+
         if offload_pattern == OFFLOAD_PATTERN_100_0:
             test_id = "lar_100_0"
             hv_1 = chk_hv_1 = None
@@ -240,7 +245,6 @@ def offload_pbo_late_100_x_tests(
         "ipa_predicate_type": ipa_predicate_type,
         "execute": True,
     }
-    messages.log(f"{test_id}:1", detail=VVERBOSE)
     offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
@@ -265,6 +269,7 @@ def offload_pbo_late_100_x_tests(
         offload_messages,
         schema,
         table_name,
+        test_id,
         "time_id = %s" % const_to_date_expr(config, OLD_HV_1),
     )
 
@@ -303,9 +308,12 @@ def offload_pbo_late_arriving_std_range_tests(
         ipa_predicate_type = INCREMENTAL_PREDICATE_TYPE_RANGE
         hv_1 = chk_hv_1 = test_constants.SALES_BASED_FACT_HV_1
         hv_pred = "(column(time_id) = datetime(%s))" % OLD_HV_1
-        add_row_fn = lambda: frontend_api.sales_based_fact_late_arriving_data_sql(
-            schema, table_name, OLD_HV_1
-        )
+
+        def add_row_fn():
+            return frontend_api.sales_based_fact_late_arriving_data_sql(
+                schema, table_name, OLD_HV_1
+            )
+
     elif table_name == LAR_TABLE_LATE:
         inc_key = "YRMON"
         ipa_predicate_type = INCREMENTAL_PREDICATE_TYPE_LIST_AS_RANGE
@@ -315,9 +323,12 @@ def offload_pbo_late_arriving_std_range_tests(
             "(column(yrmon) = datetime(%s)) and (column(time_id) = datetime(%s))"
             % (test_constants.SALES_BASED_FACT_HV_1, OLD_HV_1)
         )
-        add_row_fn = lambda: frontend_api.sales_based_list_fact_late_arriving_data_sql(
-            schema, table_name, OLD_HV_1, test_constants.SALES_BASED_FACT_HV_1
-        )
+
+        def add_row_fn():
+            return frontend_api.sales_based_list_fact_late_arriving_data_sql(
+                schema, table_name, OLD_HV_1, test_constants.SALES_BASED_FACT_HV_1
+            )
+
     elif table_name == MCOL_TABLE_LATE:
         inc_key = "TIME_YEAR, TIME_MONTH, TIME_ID"
         ipa_predicate_type = INCREMENTAL_PREDICATE_TYPE_RANGE
@@ -325,9 +336,12 @@ def offload_pbo_late_arriving_std_range_tests(
         offload_partition_granularity = "1,1,Y"
         less_than_option = "less_than_value"
         hv_pred = "(column(time_id) = datetime(%s))" % OLD_HV_1
-        add_row_fn = lambda: gen_insert_late_arriving_sales_based_multi_pcol_data(
-            schema, table_name, OLD_HV_1
-        )
+
+        def add_row_fn():
+            return gen_insert_late_arriving_sales_based_multi_pcol_data(
+                schema, table_name, OLD_HV_1
+            )
+
         check_hwm_in_metadata = False
         if config.target == DBTYPE_BIGQUERY:
             offload_partition_columns = "TIME_ID"
@@ -338,9 +352,12 @@ def offload_pbo_late_arriving_std_range_tests(
         ipa_predicate_type = INCREMENTAL_PREDICATE_TYPE_RANGE
         hv_1 = chk_hv_1 = test_constants.SALES_BASED_FACT_HV_1
         hv_pred = "(column(time_id) = datetime(%s))" % OLD_HV_1
-        add_row_fn = lambda: frontend_api.sales_based_fact_late_arriving_data_sql(
-            schema, table_name, OLD_HV_1, channel_id_literal=2
-        )
+
+        def add_row_fn():
+            return frontend_api.sales_based_fact_late_arriving_data_sql(
+                schema, table_name, OLD_HV_1, channel_id_literal=2
+            )
+
         expected_incremental_range = "SUBPARTITION"
     else:
         raise NotImplementedError(f"Test table not implemented: {table_name}")
@@ -468,7 +485,6 @@ def offload_pbo_late_arriving_std_range_tests(
         "ipa_predicate_type": ipa_predicate_type,
         "execute": True,
     }
-    messages.log(f"{test_id}:1", detail=VVERBOSE)
     offload_messages = run_offload(options, config, messages)
     assert sales_based_fact_assertion(
         config,
@@ -493,6 +509,7 @@ def offload_pbo_late_arriving_std_range_tests(
         offload_messages,
         schema,
         table_name,
+        test_id,
         chk_cnt_filter,
     )
     assert text_in_log(offload_messages, PREDICATE_APPEND_HWM_MESSAGE_TEXT, messages)

--- a/tests/integration/scenarios/test_offload_rpa.py
+++ b/tests/integration/scenarios/test_offload_rpa.py
@@ -225,7 +225,7 @@ def offload_range_ipa_standard_tests(
         "create_backend_db": True,
         "execute": True,
     }
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
 
     assert sales_based_fact_assertion(
         config,
@@ -241,6 +241,7 @@ def offload_range_ipa_standard_tests(
         backend_table=backend_name,
         partition_functions=udf,
         synthetic_partition_column_name=expected_goe_part_name,
+        offload_messages=offload_messages,
     )
 
     # RANGE Offload 2nd Partition.
@@ -253,7 +254,7 @@ def offload_range_ipa_standard_tests(
         "synthetic_partition_digits": different_partition_digits,
         "execute": True,
     }
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
 
     assert sales_based_fact_assertion(
         config,
@@ -268,6 +269,7 @@ def offload_range_ipa_standard_tests(
         incremental_key_type=part_key_type,
         partition_functions=udf,
         synthetic_partition_column_name=expected_goe_part_name,
+        offload_messages=offload_messages,
     )
 
     # RANGE Offload 3rd Partition - Verification.
@@ -276,7 +278,7 @@ def offload_range_ipa_standard_tests(
         less_than_option: hv_3,
         "execute": False,
     }
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
 
     # Assert HV is still from prior offload.
     assert sales_based_fact_assertion(
@@ -292,6 +294,7 @@ def offload_range_ipa_standard_tests(
         incremental_key_type=part_key_type,
         partition_functions=udf,
         synthetic_partition_column_name=expected_goe_part_name,
+        offload_messages=offload_messages,
     )
 
     # RANGE Offload With Multiple Partition Names - Expect Exception.
@@ -317,7 +320,7 @@ def offload_range_ipa_standard_tests(
         "verify_row_count": "aggregate",
         "execute": True,
     }
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
 
     assert sales_based_fact_assertion(
         config,
@@ -331,6 +334,7 @@ def offload_range_ipa_standard_tests(
         hv_3,
         incremental_key_type=part_key_type,
         partition_functions=udf,
+        offload_messages=offload_messages,
     )
 
     # RANGE No-op of 3rd Partition.
@@ -340,7 +344,7 @@ def offload_range_ipa_standard_tests(
         "execute": True,
     }
     # On Teradata we can't test by partition name in previous test so this test will not be a no-op.
-    run_offload(
+    offload_messages = run_offload(
         options,
         config,
         messages,
@@ -359,6 +363,7 @@ def offload_range_ipa_standard_tests(
         hv_3,
         incremental_key_type=part_key_type,
         partition_functions=udf,
+        offload_messages=offload_messages,
     )
 
     # Setup - drop oldest partition from fact.
@@ -384,7 +389,7 @@ def offload_range_ipa_standard_tests(
         less_than_option: hv_4,
         "execute": True,
     }
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
 
     assert sales_based_fact_assertion(
         config,
@@ -398,6 +403,7 @@ def offload_range_ipa_standard_tests(
         hv_4,
         incremental_key_type=part_key_type,
         partition_functions=udf,
+        offload_messages=offload_messages,
     )
 
     # Setup - drop all offloaded partitions from fact.
@@ -426,7 +432,7 @@ def offload_range_ipa_standard_tests(
         less_than_option: hv_4,
         "execute": True,
     }
-    run_offload(options, config, messages, expected_status=False)
+    offload_messages = run_offload(options, config, messages, expected_status=False)
 
     assert sales_based_fact_assertion(
         config,
@@ -440,6 +446,7 @@ def offload_range_ipa_standard_tests(
         hv_4,
         incremental_key_type=part_key_type,
         partition_functions=udf,
+        offload_messages=offload_messages,
     )
 
 
@@ -701,7 +708,7 @@ def test_offload_rpa_alpha(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
 
         assert sales_based_fact_assertion(
             config,
@@ -715,6 +722,7 @@ def test_offload_rpa_alpha(config, schema, data_db):
             "U",
             incremental_key="STR",
             incremental_key_type=canonical_string,
+            offload_messages=offload_messages,
         )
 
         # 2nd Offload By Lower Case Character.
@@ -723,7 +731,7 @@ def test_offload_rpa_alpha(config, schema, data_db):
             "less_than_value": "u",
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
 
         assert sales_based_fact_assertion(
             config,
@@ -737,6 +745,7 @@ def test_offload_rpa_alpha(config, schema, data_db):
             "u",
             incremental_key="STR",
             incremental_key_type=canonical_string,
+            offload_messages=offload_messages,
         )
 
 
@@ -784,7 +793,7 @@ def test_offload_rpa_empty_partitions(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -795,6 +804,7 @@ def test_offload_rpa_empty_partitions(config, schema, data_db):
             data_db,
             NOSEG_FACT,
             test_constants.SALES_BASED_FACT_HV_2,
+            offload_messages=offload_messages,
         )
 
         # Offload remaining empty partitions, metadata should still reflect this.
@@ -804,7 +814,7 @@ def test_offload_rpa_empty_partitions(config, schema, data_db):
             "max_offload_chunk_count": 1,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -815,4 +825,5 @@ def test_offload_rpa_empty_partitions(config, schema, data_db):
             data_db,
             NOSEG_FACT,
             test_constants.SALES_BASED_FACT_HV_5,
+            offload_messages=offload_messages,
         )

--- a/tests/integration/scenarios/test_offload_subpart.py
+++ b/tests/integration/scenarios/test_offload_subpart.py
@@ -29,9 +29,7 @@ from goe.persistence.factory.orchestration_repo_client_factory import (
     orchestration_repo_client_factory,
 )
 
-from tests.integration.scenarios.assertion_functions import (
-    sales_based_fact_assertion,
-)
+from tests.integration.scenarios.assertion_functions import sales_based_fact_assertion
 from tests.integration.scenarios import scenario_constants
 from tests.integration.scenarios.scenario_runner import (
     run_offload,
@@ -110,7 +108,7 @@ def test_offload_subpart_lr_range(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
 
         assert sales_based_fact_assertion(
             config,
@@ -123,6 +121,7 @@ def test_offload_subpart_lr_range(config, schema, data_db):
             FACT_LIST_RANGE_R,
             test_constants.SALES_BASED_FACT_HV_1,
             incremental_range="SUBPARTITION",
+            offload_messages=offload_messages,
         )
 
         # Incremental Offload of Subpartitioned Fact.
@@ -131,7 +130,7 @@ def test_offload_subpart_lr_range(config, schema, data_db):
             "older_than_date": test_constants.SALES_BASED_FACT_HV_2,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
 
         assert sales_based_fact_assertion(
             config,
@@ -144,6 +143,7 @@ def test_offload_subpart_lr_range(config, schema, data_db):
             FACT_LIST_RANGE_R,
             test_constants.SALES_BASED_FACT_HV_2,
             incremental_range="SUBPARTITION",
+            offload_messages=offload_messages,
         )
 
         # This test chooses a HWM that is not common across all list partition values and therefore should throw an exception.
@@ -172,7 +172,7 @@ def test_offload_subpart_lr_range(config, schema, data_db):
             "offload_type": OFFLOAD_TYPE_FULL,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
 
         assert sales_based_fact_assertion(
             config,
@@ -186,6 +186,7 @@ def test_offload_subpart_lr_range(config, schema, data_db):
             None,
             incremental_range="SUBPARTITION",
             offload_pattern=scenario_constants.OFFLOAD_PATTERN_100_0,
+            offload_messages=offload_messages,
         )
 
         # Offload Type FULL->INCREMENTAL of Subpartitioned Fact (Expect to Fail).
@@ -312,7 +313,7 @@ def test_offload_subpart_range_range(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -326,6 +327,7 @@ def test_offload_subpart_range_range(config, schema, data_db):
             incremental_range="PARTITION",
             incremental_key="CHANNEL_ID",
             incremental_key_type=ORACLE_TYPE_NUMBER,
+            offload_messages=offload_messages,
         )
 
         # Offload a RANGE/RANGE NUMBER/DATE table at subpartition level RANGE.
@@ -336,7 +338,7 @@ def test_offload_subpart_range_range(config, schema, data_db):
             "reset_backend_table": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -348,6 +350,7 @@ def test_offload_subpart_range_range(config, schema, data_db):
             FACT_RANGE_RANGE,
             test_constants.SALES_BASED_FACT_HV_1,
             incremental_range="SUBPARTITION",
+            offload_messages=offload_messages,
         )
 
 
@@ -386,7 +389,7 @@ def test_offload_subpart_hash_range(config, schema, data_db):
             "create_backend_db": True,
             "execute": True,
         }
-        run_offload(options, config, messages)
+        offload_messages = run_offload(options, config, messages)
         assert sales_based_fact_assertion(
             config,
             backend_api,
@@ -398,4 +401,5 @@ def test_offload_subpart_hash_range(config, schema, data_db):
             FACT_HASH_RANGE,
             test_constants.SALES_BASED_FACT_HV_1,
             incremental_range="SUBPARTITION",
+            offload_messages=offload_messages,
         )

--- a/tests/integration/scenarios/test_offload_transport.py
+++ b/tests/integration/scenarios/test_offload_transport.py
@@ -22,7 +22,6 @@ from goe.offload.offload_functions import (
     data_db_name,
     load_db_name,
 )
-from goe.offload.offload_messages import VVERBOSE
 from goe.offload.offload_transport import (
     MISSING_ROWS_IMPORTED_WARNING,
     OFFLOAD_TRANSPORT_METHOD_QUERY_IMPORT,
@@ -383,7 +382,7 @@ def test_offload_transport_spark_thrift(config, schema, data_db):
     # We don't need an equivalent for Query Import because most others tests use that method.
     id = "test_offload_transport_spark_thrift"
     with get_test_messages_ctx(config, id) as messages:
-        if not is_spark_submit_available(config, None, messages=messages):
+        if not is_spark_thrift_available(config, None, messages=messages):
             pytest.skip(f"Skipping {id} because Spark Thriftserver is not configured")
 
         simple_offload_test(

--- a/tests/integration/scenarios/test_offload_transport.py
+++ b/tests/integration/scenarios/test_offload_transport.py
@@ -107,10 +107,6 @@ def data_db(schema, config):
     return data_db
 
 
-def log_test_marker(messages, test_id):
-    messages.log(test_id, detail=VVERBOSE)
-
-
 def simple_offload_test(
     config, schema, data_db, table_name, transport_method, messages, test_id
 ):
@@ -291,13 +287,11 @@ def offload_transport_polling_validation_tests(
         "create_backend_db": True,
         "execute": True,
     }
-    log_test_marker(messages, f"{test_id}:1")
     offload_messages = run_offload(options, config, messages)
     assert text_in_log(
         offload_messages,
         POLLING_VALIDATION_TEXT % "OffloadTransportSqlStatsThread",
         messages,
-        f"{test_id}:1",
     )
 
     # Offload with disabled SQL stats validation.
@@ -308,20 +302,17 @@ def offload_transport_polling_validation_tests(
         "reset_backend_table": True,
         "execute": True,
     }
-    log_test_marker(messages, f"{test_id}:2")
     run_offload(options, config, messages)
     assert not text_in_log(
         offload_messages,
         OFFLOAD_TRANSPORT_SQL_STATISTICS_TITLE,
         messages,
-        search_from_text=f"{test_id}:2",
     )
     assert (
         text_in_log(
             offload_messages,
             MISSING_ROWS_IMPORTED_WARNING,
             messages,
-            search_from_text=f"{test_id}:2",
         )
         == expect_missing_validation_warning
     )

--- a/tests/integration/scenarios/test_offload_transport_oracle_iot.py
+++ b/tests/integration/scenarios/test_offload_transport_oracle_iot.py
@@ -95,10 +95,6 @@ def data_db(schema: str, config: OrchestrationConfig) -> str:
     return data_db
 
 
-def log_test_marker(messages, test_id):
-    messages.log(test_id, detail=VVERBOSE)
-
-
 def gen_num_dim_table_ddl(frontend_api, schema, table_name):
     ddl = [
         f"DROP TABLE {schema}.{table_name}",
@@ -179,7 +175,6 @@ def iot_num_dim_tests(
         "create_backend_db": True,
         "execute": True,
     }
-    log_test_marker(messages, test_id)
     offload_messages = run_offload(options, config, messages)
 
     assert standard_dimension_assertion(
@@ -236,7 +231,6 @@ def iot_str_dim_tests(
         "create_backend_db": True,
         "execute": True,
     }
-    log_test_marker(messages, test_id)
     offload_messages = run_offload(options, config, messages)
 
     assert standard_dimension_assertion(
@@ -293,7 +287,6 @@ def iot_ts_dim_tests(
         "create_backend_db": True,
         "execute": True,
     }
-    log_test_marker(messages, test_id)
     offload_messages = run_offload(options, config, messages)
 
     assert standard_dimension_assertion(

--- a/tests/integration/scenarios/test_offload_transport_oracle_iot.py
+++ b/tests/integration/scenarios/test_offload_transport_oracle_iot.py
@@ -44,9 +44,7 @@ from goe.persistence.factory.orchestration_repo_client_factory import (
     orchestration_repo_client_factory,
 )
 
-from tests.integration.scenarios.assertion_functions import (
-    standard_dimension_assertion,
-)
+from tests.integration.scenarios.assertion_functions import standard_dimension_assertion
 from tests.integration.scenarios.scenario_runner import (
     run_offload,
     run_setup,
@@ -182,7 +180,7 @@ def iot_num_dim_tests(
         "execute": True,
     }
     log_test_marker(messages, test_id)
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
 
     assert standard_dimension_assertion(
         config,
@@ -193,6 +191,7 @@ def iot_num_dim_tests(
         data_db,
         table_name,
         split_type=expected_split_type,
+        offload_messages=offload_messages,
     )
 
     # Connections are being left open, explicitly close them.
@@ -238,7 +237,7 @@ def iot_str_dim_tests(
         "execute": True,
     }
     log_test_marker(messages, test_id)
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
 
     assert standard_dimension_assertion(
         config,
@@ -249,6 +248,7 @@ def iot_str_dim_tests(
         data_db,
         table_name,
         split_type=expected_split_type,
+        offload_messages=offload_messages,
     )
 
     # Connections are being left open, explicitly close them.
@@ -294,7 +294,7 @@ def iot_ts_dim_tests(
         "execute": True,
     }
     log_test_marker(messages, test_id)
-    run_offload(options, config, messages)
+    offload_messages = run_offload(options, config, messages)
 
     assert standard_dimension_assertion(
         config,
@@ -305,6 +305,7 @@ def iot_ts_dim_tests(
         data_db,
         table_name,
         split_type=expected_split_type,
+        offload_messages=offload_messages,
     )
 
     # Connections are being left open, explicitly close them.

--- a/tests/integration/scenarios/test_orchestration_step_control.py
+++ b/tests/integration/scenarios/test_orchestration_step_control.py
@@ -99,7 +99,7 @@ def test_offload_step_dim(config, schema, data_db):
         offload_messages = run_offload(options, config, messages)
         assert (
             messages_step_executions(
-                offload_messages, step_title(command_steps.STEP_VALIDATE_DATA)
+                offload_messages, step_title(command_steps.STEP_VALIDATE_DATA), messages
             )
             == 0
         )
@@ -116,7 +116,9 @@ def test_offload_step_dim(config, schema, data_db):
         offload_messages = run_offload(options, config, messages)
         assert (
             messages_step_executions(
-                offload_messages, step_title(command_steps.STEP_VALIDATE_CASTS)
+                offload_messages,
+                step_title(command_steps.STEP_VALIDATE_CASTS),
+                messages,
             )
             == 0
         )
@@ -135,7 +137,9 @@ def test_offload_step_dim(config, schema, data_db):
         offload_messages = run_offload(options, config, messages)
         assert (
             messages_step_executions(
-                offload_messages, step_title(command_steps.STEP_VERIFY_EXPORTED_DATA)
+                offload_messages,
+                step_title(command_steps.STEP_VERIFY_EXPORTED_DATA),
+                messages,
             )
             == 0
         )

--- a/tests/testlib/test_framework/offload_test_messages.py
+++ b/tests/testlib/test_framework/offload_test_messages.py
@@ -30,7 +30,7 @@ class OffloadTestMessages:
     ###########################################################################
 
     def get_lines_from_log(
-        self, search_text, search_from_text="", max_matches=None
+        self, search_text, search_from_text="", max_matches=None, log_file: str = None
     ) -> list:
         """Searches for text in the logfile starting from search_from_text
         or the top of the file if search_from_text is blank.
@@ -38,7 +38,7 @@ class OffloadTestMessages:
         Be careful adding logging to this method, we can't log search_text otherwise
         we put the very thing we are searching for in the log.
         """
-        log_file = self.get_log_fh_name()
+        log_file = log_file or self.get_log_fh_name()
         if not log_file:
             return []
         start_found = bool(not search_from_text)
@@ -54,9 +54,14 @@ class OffloadTestMessages:
                             return matches
         return matches
 
-    def get_line_from_log(self, search_text, search_from_text="") -> str:
+    def get_line_from_log(
+        self, search_text, search_from_text="", log_file: str = None
+    ) -> str:
         matches = self.get_lines_from_log(
-            search_text, search_from_text=search_from_text, max_matches=1
+            search_text,
+            search_from_text=search_from_text,
+            max_matches=1,
+            log_file=log_file,
         )
         return matches[0] if matches else None
 

--- a/tests/testlib/test_framework/test_functions.py
+++ b/tests/testlib/test_framework/test_functions.py
@@ -21,11 +21,9 @@
 from contextlib import contextmanager
 
 from goe.goe import (
-    get_log_fh_name,
     log as offload_log,
     normal,
 )
-from goe.offload.offload_constants import DBTYPE_ORACLE
 from goe.offload.offload_functions import convert_backend_identifier_case, data_db_name
 from goe.offload.offload_messages import OffloadMessages
 from goe.util.goe_log_fh import GOELogFileHandle
@@ -114,11 +112,6 @@ def get_line_from_log(
         messages, search_text, search_from_text=search_from_text, max_matches=1
     )
     return matches[0] if matches else None
-
-
-def get_test_set_sql_path(directory_name, db_type=None):
-    db_type = db_type or DBTYPE_ORACLE
-    return f"test_sets/{directory_name}/sql/{db_type}"
 
 
 def goe_wide_max_columns(frontend_api, backend_api_or_count):

--- a/tests/testlib/test_framework/test_functions.py
+++ b/tests/testlib/test_framework/test_functions.py
@@ -79,13 +79,17 @@ def get_data_db_for_schema(schema, config):
 
 
 def get_lines_from_log(
-    search_text, search_from_text="", max_matches=None, file_name_override=None
+    messages: OffloadMessages,
+    search_text,
+    search_from_text="",
+    max_matches=None,
+    file_name_override=None,
 ) -> list:
     """Searches for text in the test logfile starting from the start of the
     story in the log or the top of the file if search_from_text is blank and
     returns all matching lines (up to max_matches).
     """
-    log_file = file_name_override or get_log_fh_name()
+    log_file = file_name_override or messages.get_log_fh_name()
     if not log_file:
         return []
     # We can't log search_text otherwise we put the very thing we are searching for in the log
@@ -103,9 +107,11 @@ def get_lines_from_log(
     return matches
 
 
-def get_line_from_log(search_text, search_from_text="") -> str:
+def get_line_from_log(
+    messages: OffloadMessages, search_text, search_from_text=""
+) -> str:
     matches = get_lines_from_log(
-        search_text, search_from_text=search_from_text, max_matches=1
+        messages, search_text, search_from_text=search_from_text, max_matches=1
     )
     return matches[0] if matches else None
 


### PR DESCRIPTION
Each test writes to it's own log file rather than many writing to the same. This is required if we decide to write logs to GCS where we can't interrogate log contents until it has been closed.