### PR TITLE
fix: Ensure defaulted sort columns on BigQuery do not exceed maximum

### DIFF
--- a/src/goe/offload/operation/sort_columns.py
+++ b/src/goe/offload/operation/sort_columns.py
@@ -115,6 +115,8 @@ def sort_columns_csv_to_sort_columns(
             # based on the frontend/backend combination.
             if backend_api.default_sort_columns_to_primary_key():
                 sort_columns = offload_source_table.get_primary_key_columns()
+                # Ensure we don't have too many sort columns.
+                sort_columns = sort_columns[:backend_api.max_sort_columns()]
     elif sort_columns_csv == offload_constants.SORT_COLUMNS_NONE:
         # The user requested no sorting.
         sort_columns = None

--- a/tests/integration/scenarios/test_offload_sorting.py
+++ b/tests/integration/scenarios/test_offload_sorting.py
@@ -501,7 +501,7 @@ def test_offload_sorting_many_pk_cols(config, schema, data_db):
             ],
         )
 
-        # Default Offload Of Dimension.
+        # Default Offload of Dimension.
         options = {
             "owner_table": schema + "." + MANY_PK_DIM,
             "sort_columns_csv": offload_constants.SORT_COLUMNS_NO_CHANGE,
@@ -518,5 +518,5 @@ def test_offload_sorting_many_pk_cols(config, schema, data_db):
             backend_api,
             messages,
             repo_client,
-            offload_sort_columns=",".join(sort_cols[:5]),
+            offload_sort_columns=",".join(sort_cols[:4]),
         )


### PR DESCRIPTION
This PR caps the number of sort columns defaulted from the source system primary key to 4 when Offloading to BigQuery.

Also adds a test.