### PR TITLE
feat: Add --offload-transport-snapshot option

### DIFF
--- a/src/goe/offload/factory/offload_transport_factory.py
+++ b/src/goe/offload/factory/offload_transport_factory.py
@@ -35,7 +35,6 @@ def offload_transport_factory(
     offload_options,
     messages,
     dfs_client,
-    rdbms_columns_override=None,
 ):
     """Constructs and returns an appropriate data transport object based on user inputs and RDBMS table"""
     if offload_transport_method == OFFLOAD_TRANSPORT_METHOD_QUERY_IMPORT:
@@ -51,7 +50,6 @@ def offload_transport_factory(
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
     elif offload_transport_method == OFFLOAD_TRANSPORT_METHOD_SQOOP:
         from goe.offload.hadoop.sqoop_offload_transport import (
@@ -68,7 +66,6 @@ def offload_transport_factory(
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
     elif offload_transport_method == OFFLOAD_TRANSPORT_METHOD_SQOOP_BY_QUERY:
         from goe.offload.hadoop.sqoop_offload_transport import (
@@ -85,7 +82,6 @@ def offload_transport_factory(
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
     elif offload_transport_method == OFFLOAD_TRANSPORT_METHOD_SPARK_THRIFT:
         from goe.offload.offload_transport import OffloadTransportSparkThrift
@@ -100,7 +96,6 @@ def offload_transport_factory(
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
     elif offload_transport_method == OFFLOAD_TRANSPORT_METHOD_SPARK_SUBMIT:
         from goe.offload.offload_transport import OffloadTransportSparkSubmit
@@ -115,7 +110,6 @@ def offload_transport_factory(
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
     elif offload_transport_method == OFFLOAD_TRANSPORT_METHOD_SPARK_DATAPROC_GCLOUD:
         from goe.offload.spark.dataproc_offload_transport import (
@@ -133,7 +127,6 @@ def offload_transport_factory(
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
     elif offload_transport_method == OFFLOAD_TRANSPORT_METHOD_SPARK_BATCHES_GCLOUD:
         from goe.offload.spark.dataproc_offload_transport import (
@@ -150,7 +143,6 @@ def offload_transport_factory(
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
     elif offload_transport_method == OFFLOAD_TRANSPORT_METHOD_SPARK_LIVY:
         from goe.offload.spark.livy_offload_transport import OffloadTransportSparkLivy
@@ -165,7 +157,6 @@ def offload_transport_factory(
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
     else:
         raise NotImplementedError(

--- a/src/goe/offload/frontend_api.py
+++ b/src/goe/offload/frontend_api.py
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" FrontendApiInterface: Library for logic/interaction with an RDBMS frontend.
-    This module enforces an interface with common, high level, methods and an implementation
-    for each supported RDBMS, e.g. Oracle, MSSQL
+"""FrontendApiInterface: Library for logic/interaction with an RDBMS frontend.
+This module enforces an interface with common, high level, methods and an implementation
+for each supported RDBMS, e.g. Oracle, MSSQL
 """
 
 import logging
@@ -402,6 +402,10 @@ class FrontendApiInterface(metaclass=ABCMeta):
         Example might be:
             [OracleColumn(...), OracleColumn(...)]
         """
+
+    @abstractmethod
+    def get_current_scn(self):
+        """Return the current system change number for the frontend."""
 
     @abstractmethod
     def get_db_unique_name(self) -> str:

--- a/src/goe/offload/hadoop/sqoop_offload_transport.py
+++ b/src/goe/offload/hadoop/sqoop_offload_transport.py
@@ -61,7 +61,6 @@ class OffloadTransportStandardSqoop(OffloadTransport):
         offload_options,
         messages,
         dfs_client,
-        rdbms_columns_override=None,
     ):
         """CONSTRUCTOR"""
         self._offload_transport_method = OFFLOAD_TRANSPORT_METHOD_SQOOP
@@ -73,7 +72,6 @@ class OffloadTransportStandardSqoop(OffloadTransport):
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
 
         if offload_options.db_type == DBTYPE_MSSQL:
@@ -459,7 +457,6 @@ class OffloadTransportSqoopByQuery(OffloadTransportStandardSqoop):
         offload_options,
         messages,
         dfs_client,
-        rdbms_columns_override=None,
     ):
         """CONSTRUCTOR"""
         self._offload_transport_method = OFFLOAD_TRANSPORT_METHOD_SQOOP_BY_QUERY
@@ -470,7 +467,6 @@ class OffloadTransportSqoopByQuery(OffloadTransportStandardSqoop):
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
 
     ###########################################################################

--- a/src/goe/offload/microsoft/mssql_frontend_api.py
+++ b/src/goe/offload/microsoft/mssql_frontend_api.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" MSSQLFrontendApi: Library for logic/interaction with an MSSQL frontend.
-    Implements abstract methods from FrontendApiInterface.
+"""MSSQLFrontendApi: Library for logic/interaction with an MSSQL frontend.
+Implements abstract methods from FrontendApiInterface.
 """
 
 # Standard Library
@@ -452,6 +452,11 @@ class MSSQLFrontendApi(FrontendApiInterface):
             col = MSSQLColumn.from_mssql(row)
             cols.append(col)
         return cols
+
+    def get_current_scn(self) -> int:
+        # TODO: Is min_active_rowversion() for database equivalent to v$database.current_scn?
+        # https://www.mssqltips.com/sqlservertip/3423/sql-server-rowversion-functions-minactiverowversion-vs-dbts/
+        raise NotImplementedError("MSSQL get_current_scn not implemented.")
 
     def get_db_unique_name(self) -> str:
         return self._connection_options.rdbms_dsn.split("=")[1]

--- a/src/goe/offload/microsoft/mssql_offload_source_table.py
+++ b/src/goe/offload/microsoft/mssql_offload_source_table.py
@@ -345,11 +345,6 @@ class MSSQLSourceTable(OffloadSourceTableInterface):
             "MSSQL enable_offload_by_subpartition() not implemented."
         )
 
-    def get_current_scn(self) -> int:
-        # TODO: Is min_active_rowversion() for database equivalent to v$database.current_scn?
-        # https://www.mssqltips.com/sqlservertip/3423/sql-server-rowversion-functions-minactiverowversion-vs-dbts/
-        raise NotImplementedError("MSSQL get_current_scn not implemented.")
-
     def get_hash_bucket_candidate(self):
         return self._hash_bucket_candidate
 

--- a/src/goe/offload/microsoft/mssql_offload_source_table.py
+++ b/src/goe/offload/microsoft/mssql_offload_source_table.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" MSSQLSourceTable: Library for logic/interaction with MSSQL source of an offload
-"""
+"""MSSQLSourceTable: Library for logic/interaction with MSSQL source of an offload"""
 
 import inspect
 import logging
@@ -346,8 +345,8 @@ class MSSQLSourceTable(OffloadSourceTableInterface):
             "MSSQL enable_offload_by_subpartition() not implemented."
         )
 
-    def get_current_scn(self, return_none_on_failure=False):
-        # TODO: Can get min_active_rowversion() for database which is equivalent to ORA_ROWSCN?
+    def get_current_scn(self) -> int:
+        # TODO: Is min_active_rowversion() for database equivalent to v$database.current_scn?
         # https://www.mssqltips.com/sqlservertip/3423/sql-server-rowversion-functions-minactiverowversion-vs-dbts/
         raise NotImplementedError("MSSQL get_current_scn not implemented.")
 

--- a/src/goe/offload/microsoft/mssql_offload_transport_rdbms_api.py
+++ b/src/goe/offload/microsoft/mssql_offload_transport_rdbms_api.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" OffloadTransportMSSQLApi: Library for logic/interaction with source MSSQL system during offload transport.
-"""
+"""OffloadTransportMSSQLApi: Library for logic/interaction with source MSSQL system during offload transport."""
 
 from contextlib import contextmanager
 
@@ -114,8 +113,8 @@ class OffloadTransportMSSQLApi(OffloadTransportRdbmsApiInterface):
         """No session setup hints required on MSSQL"""
         return ""
 
-    def get_rdbms_scn(self):
-        raise NotImplementedError("MSSQL get_rdbms_scn() not implemented.")
+    def get_snapshot_clause(self, transport_scn: int, consistent_read: bool) -> str:
+        return ""
 
     def get_transport_split_type(
         self,
@@ -134,7 +133,8 @@ class OffloadTransportMSSQLApi(OffloadTransportRdbmsApiInterface):
         self,
         partition_by_prm,
         rdbms_table,
-        consistent_read,
+        consistent_read: bool,
+        transport_scn: int,
         parallelism,
         offload_by_subpartition,
         mod_column,

--- a/src/goe/offload/offload.py
+++ b/src/goe/offload/offload.py
@@ -652,6 +652,14 @@ def get_offload_options(opt):
         ),
     )
     opt.add_option(
+        "--offload-transport-snapshot",
+        dest="offload_transport_snapshot",
+        help=(
+            "Override RDBMS snapshot (SCN) used for transport query consistency. "
+            "This defaults to the system snapshot prior to copying data if not overridden by this option."
+        ),
+    )
+    opt.add_option(
         "--offload-transport-spark-properties",
         dest="offload_transport_spark_properties",
         default=orchestration_defaults.offload_transport_spark_properties_default(),

--- a/src/goe/offload/offload_source_table.py
+++ b/src/goe/offload/offload_source_table.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" OffloadSourceTable: Library for logic/interaction with source of an offload
-"""
+"""OffloadSourceTable: Library for logic/interaction with source of an offload"""
 
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
@@ -527,6 +526,7 @@ class OffloadSourceTableInterface(metaclass=ABCMeta):
 
     @abstractmethod
     def get_current_scn(self):
+        """Return the current system change number for the source RDBMS."""
         pass
 
     def get_partition_column_data_types(self):

--- a/src/goe/offload/offload_source_table.py
+++ b/src/goe/offload/offload_source_table.py
@@ -524,10 +524,9 @@ class OffloadSourceTableInterface(metaclass=ABCMeta):
         else:
             return match[0]
 
-    @abstractmethod
     def get_current_scn(self):
         """Return the current system change number for the source RDBMS."""
-        pass
+        return self._db_api.get_current_scn()
 
     def get_partition_column_data_types(self):
         return [col.data_type for col in self.partition_columns]

--- a/src/goe/offload/offload_transport_rdbms_api.py
+++ b/src/goe/offload/offload_transport_rdbms_api.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" OffloadTransportRdbmsApi: Library for logic/interaction with source RDBMS during offload transport
-"""
+"""OffloadTransportRdbmsApi: Library for logic/interaction with source RDBMS during offload transport"""
 
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
@@ -188,7 +187,7 @@ class OffloadTransportRdbmsApiInterface(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_rdbms_scn(self):
+    def get_snapshot_clause(self, transport_scn: int, consistent_read: bool) -> str:
         pass
 
     @abstractmethod
@@ -210,6 +209,7 @@ class OffloadTransportRdbmsApiInterface(metaclass=ABCMeta):
         partition_by_prm: str,
         rdbms_table: "OffloadSourceTableInterface",
         consistent_read,
+        transport_scn: int,
         parallelism,
         offload_by_subpartition,
         mod_column,

--- a/src/goe/offload/oracle/oracle_frontend_api.py
+++ b/src/goe/offload/oracle/oracle_frontend_api.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" OracleFrontendApi: Library for logic/interaction with an Oracle frontend.
-    Implements abstract methods from FrontendApiInterface.
+"""OracleFrontendApi: Library for logic/interaction with an Oracle frontend.
+Implements abstract methods from FrontendApiInterface.
 """
 
 # Standard Library
@@ -907,6 +907,11 @@ class OracleFrontendApi(FrontendApiInterface):
             col = OracleColumn.from_oracle(row)
             cols.append(col)
         return cols
+
+    def get_current_scn(self) -> int:
+        """Return the current system change number for the source RDBMS."""
+        row = self.execute_query_fetch_one("SELECT current_scn FROM v$database")
+        return row[0] if row else row
 
     def get_db_unique_name(self) -> str:
         sql = dedent(

--- a/src/goe/offload/oracle/oracle_offload_source_table.py
+++ b/src/goe/offload/oracle/oracle_offload_source_table.py
@@ -932,11 +932,6 @@ class OracleSourceTable(OffloadSourceTableInterface):
         """
         self._offload_by_subpartition = desired_state
 
-    def get_current_scn(self) -> int:
-        """Return the current system change number for the source RDBMS."""
-        row = self._db_api.execute_query_fetch_one("SELECT current_scn FROM v$database")
-        return row[0] if row else row
-
     def get_hash_bucket_candidate(self):
         if not self._hash_bucket_candidate:
             self._hash_bucket_candidate = self._get_hash_bucket_candidate()

--- a/src/goe/offload/spark/dataproc_offload_transport.py
+++ b/src/goe/offload/spark/dataproc_offload_transport.py
@@ -60,7 +60,6 @@ class OffloadTransportSparkBatchesGcloud(OffloadTransportSpark):
         offload_options: "OrchestrationConfig",
         messages: "OffloadMessages",
         dfs_client,
-        rdbms_columns_override=None,
     ):
         """CONSTRUCTOR"""
         self._offload_transport_method = OFFLOAD_TRANSPORT_METHOD_SPARK_BATCHES_GCLOUD
@@ -71,7 +70,6 @@ class OffloadTransportSparkBatchesGcloud(OffloadTransportSpark):
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
         # For spark-submit we need to pass compression in as a config to the driver program
         self._load_table_compression_pyspark_settings()

--- a/src/goe/offload/spark/livy_offload_transport.py
+++ b/src/goe/offload/spark/livy_offload_transport.py
@@ -68,7 +68,6 @@ class OffloadTransportSparkLivy(OffloadTransportSpark):
         offload_options,
         messages,
         dfs_client,
-        rdbms_columns_override=None,
     ):
         """CONSTRUCTOR"""
         self._offload_transport_method = OFFLOAD_TRANSPORT_METHOD_SPARK_LIVY
@@ -79,7 +78,6 @@ class OffloadTransportSparkLivy(OffloadTransportSpark):
             offload_options,
             messages,
             dfs_client,
-            rdbms_columns_override=rdbms_columns_override,
         )
         assert (
             offload_options.offload_transport_livy_api_url

--- a/src/goe/offload/teradata/teradata_frontend_api.py
+++ b/src/goe/offload/teradata/teradata_frontend_api.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" TeradataFrontendApi: Library for logic/interaction with an Oracle frontend.
-    Implements abstract methods from FrontendApiInterface.
+"""TeradataFrontendApi: Library for logic/interaction with an Oracle frontend.
+Implements abstract methods from FrontendApiInterface.
 """
 
 # Standard Library
@@ -740,6 +740,9 @@ class TeradataFrontendApi(FrontendApiInterface):
         raise NotImplementedError(
             "Teradata get_command_execution_steps is not implemented."
         )
+
+    def get_current_scn(self) -> int:
+        return None
 
     def get_partition_columns(self, schema, table_name):
         """Return columns in the first row partition expression, i.e. we skip columnar partitioning."""

--- a/src/goe/offload/teradata/teradata_offload_source_table.py
+++ b/src/goe/offload/teradata/teradata_offload_source_table.py
@@ -761,10 +761,6 @@ class TeradataSourceTable(OffloadSourceTableInterface):
     def gen_default_numeric_column(self, column_name):
         return self.gen_column(column_name, TERADATA_TYPE_NUMBER)
 
-    def get_current_scn(self) -> int:
-        """Current System Change Number irrelevant for Teradata support"""
-        return None
-
     def get_hash_bucket_candidate(self):
         if not self._hash_bucket_candidate:
             self._hash_bucket_candidate = self._get_hash_bucket_candidate()

--- a/src/goe/offload/teradata/teradata_offload_source_table.py
+++ b/src/goe/offload/teradata/teradata_offload_source_table.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" TeradataSourceTable: Library for logic/interaction with Teradata source of an offload
-"""
+"""TeradataSourceTable: Library for logic/interaction with Teradata source of an offload"""
 
 from datetime import date, datetime
 import logging
@@ -762,7 +761,7 @@ class TeradataSourceTable(OffloadSourceTableInterface):
     def gen_default_numeric_column(self, column_name):
         return self.gen_column(column_name, TERADATA_TYPE_NUMBER)
 
-    def get_current_scn(self, return_none_on_failure=False):
+    def get_current_scn(self) -> int:
         """Current System Change Number irrelevant for Teradata support"""
         return None
 

--- a/src/goe/offload/teradata/teradata_offload_transport_rdbms_api.py
+++ b/src/goe/offload/teradata/teradata_offload_transport_rdbms_api.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" OffloadTransportTeradataApi: Library for logic/interaction with source Oracle system during offload transport.
-"""
+"""OffloadTransportTeradataApi: Library for logic/interaction with source Oracle system during offload transport."""
 
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
@@ -284,9 +283,6 @@ class OffloadTransportTeradataApi(OffloadTransportRdbmsApiInterface):
         """No hints on Teradata"""
         return ""
 
-    def get_rdbms_scn(self):
-        raise NotImplementedError("Teradata get_rdbms_scn() not implemented")
-
     def get_id_column_for_range_splitting(
         self, rdbms_table: "OffloadSourceTableInterface"
     ) -> "ColumnMetadataInterface":
@@ -298,6 +294,9 @@ class OffloadTransportTeradataApi(OffloadTransportRdbmsApiInterface):
         if pk_col.is_number_based() or pk_col.is_date_based():
             return pk_col
         return None
+
+    def get_snapshot_clause(self, transport_scn: int, consistent_read: bool) -> str:
+        return ""
 
     def get_transport_split_type(
         self,
@@ -409,7 +408,8 @@ class OffloadTransportTeradataApi(OffloadTransportRdbmsApiInterface):
         self,
         partition_by_prm,
         rdbms_table,
-        consistent_read,
+        consistent_read: bool,
+        transport_scn: int,
         parallelism,
         offload_by_subpartition,
         mod_column,

--- a/tests/integration/offload/test_offload_source_table.py
+++ b/tests/integration/offload/test_offload_source_table.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" TestOffloadSourceTable: Unit test library to test API for all supported frontend RDBMSs
-    This is split into two categories:
-    1) For all possible frontends test API calls that do not need to connect to the system.
-       Because there is no connection we can fake any backend and test functionality. These classes
-       have the system in the name: TestOracleOffloadSourceTable, TestMSSQLOffloadSourceTable, etc
-    2) For the current backend test API calls that need to connect to the system.
-       This class has Current in the name: TestCurrentOffloadSourceTable
+"""TestOffloadSourceTable: Unit test library to test API for all supported frontend RDBMSs
+This is split into two categories:
+1) For all possible frontends test API calls that do not need to connect to the system.
+   Because there is no connection we can fake any backend and test functionality. These classes
+   have the system in the name: TestOracleOffloadSourceTable, TestMSSQLOffloadSourceTable, etc
+2) For the current backend test API calls that need to connect to the system.
+   This class has Current in the name: TestCurrentOffloadSourceTable
 """
 from unittest import TestCase, main
 

--- a/tests/testlib/test_framework/frontend_testing_api.py
+++ b/tests/testlib/test_framework/frontend_testing_api.py
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" FrontendTestingApi: An extension of (not yet created) FrontendApi used purely for code relating to the setup,
-    processing and verification of integration tests.
+"""FrontendTestingApi: An extension of (not yet created) FrontendApi used purely for code relating to the setup,
+processing and verification of integration tests.
 """
 
 import logging
@@ -376,6 +376,9 @@ class FrontendTestingApiInterface(metaclass=ABCMeta):
 
     def get_columns(self, schema, table_name):
         return self._db_api.get_columns(schema, table_name)
+
+    def get_current_scn(self) -> int:
+        return self._db_api.get_current_scn()
 
     def get_max_range_partition_name_and_hv(
         self, schema: str, table_name: str

--- a/tests/unit/offload/test_frontend_api.py
+++ b/tests/unit/offload/test_frontend_api.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" TestFrontendApi: Unit test library to test API for all supported RDBMSs
-    1) For all possible frontends test API calls that do not need to connect to the system
-       Because there is no connection we can fake any frontend and test functionality
-       These classes have the system in the name, e.g.: TestOracleFrontendApi, TestMSSQLFrontendApi, etc
+"""TestFrontendApi: Unit test library to test API for all supported RDBMSs
+1) For all possible frontends test API calls that do not need to connect to the system
+   Because there is no connection we can fake any frontend and test functionality
+   These classes have the system in the name, e.g.: TestOracleFrontendApi, TestMSSQLFrontendApi, etc
 """
 
 from datetime import datetime
@@ -200,6 +200,13 @@ class TestFrontendApi(TestCase):
             if column_list:
                 self.assertIsInstance(column_list[0], ColumnMetadataInterface)
 
+    def _test_get_current_scn(self):
+        if self.connect_to_frontend:
+            try:
+                self.assertIsInstance(self.api.get_current_scn(), int)
+            except NotImplementedError:
+                pass
+
     def _test_get_db_unique_name(self):
         if self.connect_to_frontend:
             try:
@@ -329,6 +336,7 @@ class TestFrontendApi(TestCase):
         self._test_goe_db_component_version()
         self._test_get_column_names()
         self._test_get_columns()
+        self._test_get_current_scn()
         self._test_get_db_unique_name()
         self._test_get_distinct_column_values()
         self._test_get_partition_columns()

--- a/tests/unit/offload/test_offload_transport_rdbms_api.py
+++ b/tests/unit/offload/test_offload_transport_rdbms_api.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" TestOffloadTransportRdbmsApi: Unit tests for each Offload Transport RDBMS API.
-"""
+"""TestOffloadTransportRdbmsApi: Unit tests for each Offload Transport RDBMS API."""
 import pytest
 
 from goe.offload.factory.offload_transport_rdbms_api_factory import (
@@ -102,6 +101,9 @@ def test_oracle_ot_rdbms_api(oracle_config, messages):
         rdbms_owner, rdbms_table, oracle_config, messages, dry_run=True
     )
     non_connecting_tests(api)
+    assert isinstance(api.get_snapshot_clause(123456, True), str)
+    assert "123456" in api.get_snapshot_clause(123456, True)
+    assert "123456" not in api.get_snapshot_clause(123456, False)
 
 
 def test_teradata_ot_rdbms_api(messages):

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -324,6 +324,7 @@ def build_mock_offload_operation():
     fake_operation.offload_transport_fetch_size = 100
     fake_operation.offload_transport_parallelism = 4
     fake_operation.offload_transport_small_table_threshold = 1024 * 1024
+    fake_operation.offload_transport_snapshot = None
     fake_operation.offload_transport_spark_properties = {}
     fake_operation.unicode_string_columns_csv = None
     fake_operation.max_offload_chunk_size = 100 * 1024 * 1024


### PR DESCRIPTION
This PR:

1. Sync's up the pre-offload SCN (OFFLOAD_SNAPSHOT) with the SCN used in Offload Transport. In GDP they had different purposes but now then can be aligned which facilitates using GOE with a CDC tool.
2. Add's a new option `--offload-transport-snapshot` which again facilitates using GOE with a CDC tool.