### PR TITLE
fix: Add ORA-3135 to error codes that trigger reconnection

### DIFF
--- a/src/goe/offload/oracle/oracle_frontend_api.py
+++ b/src/goe/offload/oracle/oracle_frontend_api.py
@@ -264,12 +264,10 @@ class OracleFrontendApi(FrontendApiInterface):
             )
 
         sql = (
-            dedent(
-                """\
+            dedent("""\
             CREATE TABLE %(owner_table)s (
                 %(col_projection)s
-            )%(partition_clause)s"""
-            )
+            )%(partition_clause)s""")
             % {
                 "owner_table": self.enclose_object_reference(schema, table_name),
                 "col_projection": col_projection,
@@ -590,9 +588,7 @@ class OracleFrontendApi(FrontendApiInterface):
         if remap_schema:
             remap_command = "dbms_metadata.set_remap_param(th, 'REMAP_SCHEMA', :owner, :remap_schema);"
             params["remap_schema"] = remap_schema
-        q = (
-            dedent(
-                """\
+        q = dedent("""\
                 DECLARE
                   h   NUMBER;
                   th  NUMBER;
@@ -605,10 +601,7 @@ class OracleFrontendApi(FrontendApiInterface):
                   th := dbms_metadata.add_transform(h,'DDL');
                   :ddl := dbms_metadata.fetch_clob(h);
                   dbms_metadata.close(h);
-                END;"""
-            )
-            % {"remap_command": remap_command}
-        )
+                END;""") % {"remap_command": remap_command}
         self._log(
             "Fetch %s %s.%s SQL:\n%s" % (object_type.lower(), schema, object_name, q),
             detail=VVERBOSE,
@@ -645,14 +638,12 @@ class OracleFrontendApi(FrontendApiInterface):
             "dba_subpart_key_columns" if subpartition_level else "dba_part_key_columns"
         )
         q = (
-            dedent(
-                """\
+            dedent("""\
             SELECT UPPER(pk.column_name)
             FROM   %(dba_part_key_columns)s pk
             WHERE  pk.owner = :owner
             AND    pk.name = :table_name
-            ORDER BY pk.column_position"""
-            )
+            ORDER BY pk.column_position""")
             % {"dba_part_key_columns": dba_part_key_columns}
         )
         return [
@@ -738,12 +729,15 @@ class OracleFrontendApi(FrontendApiInterface):
                         "ORA-3113",
                         "ORA-03114",
                         "ORA-3114",
+                        "ORA-03135",
+                        "ORA-3135",
                     )
                 ):
                     # Reconnect and try again (not in a loop, just try once and if we can't get going again then fail)
                     # "ORA-02396: exceeded maximum idle time, please connect again": Session sniped due to profile.
                     # "ORA-03113: end-of-file on communication channel: comes hand in hand with ORA-03114.
                     # "ORA-03114: not connected to Oracle": e.g. when a firewall rule severs an idle session.
+                    # "ORA-03135: connection lost contact": e.g. when a firewall rule severs an idle session.
                     # Sometimes error codes are not padded with a zero, for example:
                     #    DPI-1080: connection was closed by ORA-2396
                     self._log(
@@ -790,8 +784,7 @@ class OracleFrontendApi(FrontendApiInterface):
     def agg_validate_sample_column_names(
         self, schema, table_name, num_required: int = 5
     ) -> list:
-        sql = dedent(
-            """\
+        sql = dedent("""\
         SELECT column_name
         FROM  (
                SELECT column_name
@@ -804,8 +797,7 @@ class OracleFrontendApi(FrontendApiInterface):
                AND    hidden_column = 'NO'
               )
         WHERE  column_id IN (1, last_column_id)
-        OR     ndv_rank <= :REQUIRED_NO"""
-        )
+        OR     ndv_rank <= :REQUIRED_NO""")
         binds = [
             QueryParameter(param_name="OWNER", param_value=schema),
             QueryParameter(param_name="TABLE_NAME", param_value=table_name),
@@ -914,8 +906,7 @@ class OracleFrontendApi(FrontendApiInterface):
         return row[0] if row else row
 
     def get_db_unique_name(self) -> str:
-        sql = dedent(
-            """\
+        sql = dedent("""\
         SELECT SYS_CONTEXT('USERENV', 'DB_UNIQUE_NAME') ||
                CASE
                   WHEN version >= 12
@@ -928,8 +919,7 @@ class OracleFrontendApi(FrontendApiInterface):
                SELECT TO_NUMBER(REGEXP_SUBSTR(version, '[0-9]+')) AS version
                FROM   v$instance
               )
-        """
-        )
+        """)
         row = self.execute_query_fetch_one(sql)
         return row[0] if row else row
 

--- a/tests/unit/offload/test_frontend_api.py
+++ b/tests/unit/offload/test_frontend_api.py
@@ -20,8 +20,10 @@
 
 from datetime import datetime
 from unittest import TestCase, main
+import unittest.mock as mock
 
 from numpy import datetime64
+import oracledb as cxo
 
 from goe.offload.column_metadata import ColumnMetadataInterface
 from goe.offload.factory.frontend_api_factory import frontend_api_factory
@@ -376,6 +378,72 @@ class TestOracleFrontendApi(TestFrontendApi):
 
     def test_all_non_connecting_oracle_tests(self):
         self._run_all_tests()
+
+    def test_oracle_reconnect(self):
+        error_codes = [
+            "ORA-02396",
+            "ORA-2396",
+            "ORA-03113",
+            "ORA-3113",
+            "ORA-03114",
+            "ORA-3114",
+            "ORA-03135",
+            "ORA-3135",
+        ]
+
+        for error_code in error_codes:
+            with self.subTest(error_code=error_code):
+                # 1. Mock the database connection and cursor
+                mock_conn = mock.Mock()
+                mock_cursor = mock.Mock()
+                mock_conn.cursor.return_value = mock_cursor
+
+                # Set the mocked connection on the frontend API
+                self.api._db_conn = mock_conn
+
+                # 2. Mock _connect and _disconnect to avoid actual connection attempts
+                self.api._connect = mock.Mock()
+                self.api._disconnect = mock.Mock()
+
+                # 3. Configure the cursor execute to raise DatabaseError on the first call
+                # and succeed (return None) on the second call.
+                exc = cxo.DatabaseError(f"{error_code}: connection lost or session sniped")
+                mock_cursor.execute.side_effect = [exc, None]
+
+                # 4. Call _open_cursor and verify it triggers reconnect
+                self.api._open_cursor()
+
+                # 5. Assertions
+                self.api._disconnect.assert_called_once_with(force=True)
+                self.api._connect.assert_called_once()
+                self.assertEqual(mock_cursor.execute.call_count, 2)
+                self.assertEqual(self.api._db_curs, mock_cursor)
+
+    def test_oracle_no_reconnect_on_other_errors(self):
+        # 1. Mock the database connection and cursor
+        mock_conn = mock.Mock()
+        mock_cursor = mock.Mock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        # Set the mocked connection on the frontend API
+        self.api._db_conn = mock_conn
+
+        # 2. Mock _connect and _disconnect
+        self.api._connect = mock.Mock()
+        self.api._disconnect = mock.Mock()
+
+        # 3. Configure the cursor execute to raise DatabaseError for a different error (e.g. ORA-00942)
+        exc = cxo.DatabaseError("ORA-00942: table or view does not exist")
+        mock_cursor.execute.side_effect = exc
+
+        # 4. Verify it propagates the exception and does not attempt to reconnect
+        with self.assertRaises(cxo.DatabaseError):
+            self.api._open_cursor()
+
+        # 5. Assertions
+        self.api._disconnect.assert_not_called()
+        self.api._connect.assert_not_called()
+        self.assertEqual(mock_cursor.execute.call_count, 1)
 
 
 class TestTeradataFrontendApi(TestFrontendApi):


### PR DESCRIPTION
Another Oracle error most likely indicating a firewall/network drop out.

This changes includes it in the list of codes that Offload attempts to recover from.