### PR TITLE
fix: Downgrade NLS_LANG test from failure to warning

### DIFF
--- a/src/goe/connect/connect_frontend.py
+++ b/src/goe/connect/connect_frontend.py
@@ -25,6 +25,7 @@ from goe.connect.connect_functions import (
     log,
     success,
     test_header,
+    warning,
 )
 from goe.offload.factory.frontend_api_factory import frontend_api_factory
 from goe.offload import offload_constants
@@ -40,7 +41,6 @@ from goe.goe import (
     verbose,
     NLS_LANG_MISSING_CHARACTER_SET_EXCEPTION_TEMPLATE,
 )
-
 
 GOE_MINIMUM_ORACLE_VERSION = "10.2.0.1"
 
@@ -141,7 +141,7 @@ def test_oracle(orchestration_config, messages):
             'NLS_LANG not specified in environment, this will be set at offload time to "%s"'
             % os.environ["NLS_LANG"]
         )
-        failure(test_name)
+        warning(test_name)
     else:
         if not nls_lang_has_charset():
             detail(


### PR DESCRIPTION
When the user doesn't set NLS_LANG explicitly we default to the correct one for the database so having this as a failure is misleading. This PR downgrades it to a warning.