### PR TITLE
chore: Remove Oracle v$parameter check from connect

### DIFF
--- a/docs/internal/design_docs/connect_design_document.md
+++ b/docs/internal/design_docs/connect_design_document.md
@@ -63,9 +63,6 @@ graph TD
 * **Component Version Matching**: Compares the version of the installed database components (compiled schema packages) against the client binary version to ensure they are synchronized.
 * **Metadata & Parameters (Informational)**:
   * Queries session attributes (`DB_UNIQUE_NAME`, `SESSION_USER`) and character sets (`NLS_CHARACTERSET`, `NLS_NCHAR_CHARACTERSET`).
-  * Queries database parameters: `processes`, `sessions`, `query_rewrite_enabled`, and `_optimizer_cartesian_enabled`.
-  * > [!NOTE]
-  * > The database parameters are collected for diagnostic and informational purposes only. No threshold assertions are applied. This section is slated for removal in a future release per **GitHub Issue #265**.
 
 ### 3.3. Backend Checks (BigQuery)
 * **API Access & Connection**: Instantiates the BigQuery backend API client and queries the backend user identity to confirm that the BigQuery API is enabled and accessible.

--- a/src/goe/connect/connect.py
+++ b/src/goe/connect/connect.py
@@ -69,7 +69,6 @@ from goe.util.goe_log import log_exception
 from goe.util.misc_functions import unsurround
 from goe.util.redis_tools import RedisClient
 
-
 OS_RELEASE_FILE_REDHAT = "/etc/redhat-release"
 OS_RELEASE_FILE_SUSE = "/etc/SuSE-release"
 OS_RELEASE_FILE_DEBIAN = "/etc/os-release"

--- a/src/goe/connect/connect_frontend.py
+++ b/src/goe/connect/connect_frontend.py
@@ -224,34 +224,6 @@ def test_oracle(orchestration_config, messages):
             detail(exc)
             failure(test_name)
 
-    test_name = "Oracle Parameters"
-    test_header(test_name)
-
-    db_parameters = [
-        "processes",
-        "sessions",
-        "query_rewrite_enabled",
-        "_optimizer_cartesian_enabled",
-    ]
-    binds = {}
-
-    for count, value in enumerate(db_parameters):
-        binds["b" + str(count)] = value
-
-    sql = (
-        "select name, value from gv$parameter where name in (%s) group by name, value order by 1,2"
-        % ",".join([":" + _ for _ in binds])
-    )
-    db_parameter_values = frontend_api.execute_query_fetch_all(sql, query_params=binds)
-    col1_width = max(
-        max([len(row[0]) for row in db_parameter_values]), len("Parameter")
-    )
-    col2_width = max(max([len(row[1]) for row in db_parameter_values]), len("Value"))
-    parameter_format = "{0:" + str(col1_width) + "}     {1:>" + str(col2_width) + "}"
-    detail(parameter_format.format("Parameter", "Value"))
-    for row in db_parameter_values:
-        detail(parameter_format.format(row[0], row[1]))
-
     cx.close()
 
 


### PR DESCRIPTION
Removes information on 4 Oracle init params from connect.

Primarily `query_rewrite_enabled` is no longer of interest to GOE, but the other reported parameters are not used and are just noise in the output.