### PR TITLE
chore: Update Spark dependencies for Spark Listener

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -5,7 +5,7 @@ You are an AI coding assistant helping develop the GOE framework repository. Alw
 ## 1. Tech Stack & Environment
 - **Language**: Python.
 - **Core Domain**: Data offloading and copying from Oracle Database to cloud data warehouses (Google BigQuery, Snowflake, Azure Synapse, Teradata) and Hadoop.
-- **Supporting Infrastructure**: Relies on Spark/Dataproc, Cloud Storage (GCS, S3, Azure Blob), and Oracle RDBMS.
+- **Supporting Infrastructure**: Relies on Spark, Cloud Storage (GCS, S3, Azure Blob), and Oracle RDBMS.
 
 ## 2. Environment & Dependency Management
 - **Virtual Environment**: The development virtual environment is located in a local `.venv` directory. Always assume activation via `source .venv/bin/activate`.

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Variables you will want to pay attention to are:
 - OFFLOAD_FS_CONTAINER
 - OFFLOAD_FS_PREFIX
 
-If using Dataproc to provide Spark:
+If using Google Managed Service for Apache Spark:
 - GOOGLE_DATAPROC_CLUSTER
 - GOOGLE_DATAPROC_SERVICE_ACCOUNT
 - GOOGLE_DATAPROC_REGION
 
-If using Dataproc Batches to provide Spark:
+If using Google Managed Service for Apache Spark serverless:
 - GOOGLE_DATAPROC_BATCHES_VERSION
 - GOOGLE_DATAPROC_SERVICE_ACCOUNT
 - GOOGLE_DATAPROC_REGION

--- a/docs/gcp_setup.md
+++ b/docs/gcp_setup.md
@@ -43,12 +43,12 @@ The role names below are used throughput this page but can be changed to suit co
 
 | Role                | Mandatory | Purpose                                                                         |
 | :------------------ | :-------: | :------------------------------------------------------------------------------ |
-| `goe_gcs_role`      |     Y     | - Permissions to read/write on the GOE staging bucket.                            |
-| `goe_bq_core_role`  |     Y     | - Core permissions to interact with BigQuery, list datasets/tables/etc.<br />- No data read/write permissions.<br />- Will be granted at the project level. |
-| `goe_bq_app_role`   |     Y     | - Permissions to read/write data in the final dataset.<br />- Optionally can include table create/drop permissions.<br />- Locked down at dataset level. |
-| `goe_bq_stg_role`   |     Y     | - Permissions to read data and create/drop staging tables in the staging dataset.<br />- Locked down at dataset level. |
-| `goe_dataproc_role` |     N     | - Permissions to interact with a permanent Managed Service for Apache Spark (permanent). |
-| `goe_batches_role`  |     N     | - Permissions to interact with Managed Service for Apache Spark (serverless).     |
+| `goe_gcs_role`           |     Y     | - Permissions to read/write on the GOE staging bucket.                            |
+| `goe_bq_core_role`       |     Y     | - Core permissions to interact with BigQuery, list datasets/tables/etc.<br />- No data read/write permissions.<br />- Will be granted at the project level. |
+| `goe_bq_app_role`        |     Y     | - Permissions to read/write data in the final dataset.<br />- Optionally can include table create/drop permissions.<br />- Locked down at dataset level. |
+| `goe_bq_stg_role`        |     Y     | - Permissions to read data and create/drop staging tables in the staging dataset.<br />- Locked down at dataset level. |
+| `goe_spark_role`           |     N     | - Permissions to interact with a permanent Managed Service for Apache Spark (permanent). |
+| `goe_spark_serverless_role`  |     N     | - Permissions to interact with Managed Service for Apache Spark (serverless).     |
 
 ### Compute Engine Virtual Machine
 
@@ -123,12 +123,12 @@ Values supplied below are examples only, changes will likely be required for eac
 ```shell
 SUBNET=<your-subnet>
 CLUSTER_NAME=<cluster-name>
-DP_SVC_ACCOUNT=goe-dataproc
+DP_SVC_ACCOUNT=goe-managed-spark
 ZONE=<your-zone>
 
 gcloud iam service-accounts create ${DP_SVC_ACCOUNT} \
 --project=${PROJECT} \
---description="GOE Dataproc service account"
+--description="GOE Managed Spark service account"
 
 gcloud projects add-iam-policy-binding ${PROJECT} \
 --member=serviceAccount:${DP_SVC_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com \
@@ -256,11 +256,11 @@ TO \"serviceAccount:${SVC_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com\";
 " | bq query --project_id=${PROJECT} --nouse_legacy_sql --location=${LOCATION}
 ```
 
-#### goe_dataproc_role
+#### goe_spark_role
 
 ```shell
-gcloud iam roles create goe_dataproc_role --project ${PROJECT} \
---title="GOE Dataproc Access" --description="GOE Dataproc Access" \
+gcloud iam roles create goe_spark_role --project ${PROJECT} \
+--title="GOE Managed Spark Access" --description="GOE Managed Spark Access" \
 --permissions=dataproc.clusters.get,dataproc.clusters.use,\
 dataproc.jobs.create,dataproc.jobs.get,\
 iam.serviceAccounts.getAccessToken \
@@ -268,24 +268,24 @@ iam.serviceAccounts.getAccessToken \
 
 gcloud projects add-iam-policy-binding ${PROJECT} \
 --member=serviceAccount:${SVC_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com \
---role=projects/${PROJECT}/roles/goe_dataproc_role
+--role=projects/${PROJECT}/roles/goe_spark_role
 
 gcloud projects add-iam-policy-binding ${PROJECT} \
 --member=serviceAccount:${SVC_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com \
 --role=roles/iam.serviceAccountUser
 ```
 
-#### goe_batches_role
+#### goe_spark_serverless_role
 
 ```shell
-gcloud iam roles create goe_batches_role --project ${PROJECT} \
---title="GOE Dataproc Access" --description="GOE Dataproc Access" \
+gcloud iam roles create goe_spark_serverless_role --project ${PROJECT} \
+--title="GOE Managed Spark Access" --description="GOE Managed Spark Access" \
 --permissions=dataproc.batches.create,dataproc.batches.get \
 --stage=GA
 
 gcloud projects add-iam-policy-binding ${PROJECT} \
 --member=serviceAccount:${SVC_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com \
---role=projects/${PROJECT}/roles/goe_batches_role
+--role=projects/${PROJECT}/roles/goe_spark_serverless_role
 ```
 
 ## Compute Engine Virtual Machine

--- a/docs/gcp_setup.md
+++ b/docs/gcp_setup.md
@@ -1,5 +1,11 @@
 # Google Cloud Platform Setup for a BigQuery Target
 
+- [Overview](#overview)
+- [Example Commands](#example-commands)
+- [Managed Spark version implications](#managed-spark-version-implications)
+- [Compute Engine Virtual Machine](#compute-engine-virtual-machine)
+- [Generating Dataset DDL](#generating-dataset-ddl)
+
 ## Overview
 
 This page details Google Cloud Platform (GCP) components required, with recommended minimal privileges, to use GOE in your GCP project.
@@ -286,6 +292,38 @@ gcloud iam roles create goe_spark_serverless_role --project ${PROJECT} \
 gcloud projects add-iam-policy-binding ${PROJECT} \
 --member=serviceAccount:${SVC_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com \
 --role=projects/${PROJECT}/roles/goe_spark_serverless_role
+```
+
+## Managed Spark version implications
+
+### Avro driver support
+
+The version of Spark in the Managed Spark environment dictates the version of the Avro driver to use:
+
+| GOOGLE_DATAPROC_BATCHES_VERSION | Avro driver                            |
+| :------------------------------ | :------------------------------------- |
+| 1.1                             | org.apache.spark:spark-avro_2.12:3.3.0 |
+| 1.2                             | org.apache.spark:spark-avro_2.12:3.5.1 |
+| 2.1                             | org.apache.spark:spark-avro_2.13:3.5.1 |
+| 2.2                             | org.apache.spark:spark-avro_2.13:3.5.3 |
+
+`OFFLOAD_TRANSPORT_SPARK_PROPERTIES` should be updated accordingly.
+
+### GOE Spark Listener
+
+The GOE Spark listener is used to collect performance metrics from the Spark jobs created by Offload. The listener is only invoked when using the Spark transport method.
+
+| GOOGLE_DATAPROC_BATCHES_VERSION | Listener JAR file                     |
+| :------------------------------ | :------------------------------------ |
+| 1.1                             | goe-spark-3.3.0-listener_2.12-1.0.jar |
+| 1.2                             | goe-spark-3.5.1-listener_2.12-1.0.jar |
+| 2.1                             | goe-spark-3.5.1-listener_2.13-1.0.jar |
+| 2.2                             | goe-spark-3.5.3-listener_2.13-1.0.jar |
+
+The correct JAR file should be copied into place inside the `$OFFLOAD_HOME/lib/` directory, e.g.:
+
+```shell
+cp ${OFFLOAD_HOME}/lib/goe-spark-3.5.3-listener_2.13-1.0.jar ${OFFLOAD_HOME}/lib/goe-spark-listener.jar
 ```
 
 ## Compute Engine Virtual Machine

--- a/docs/internal/design_docs/connect_design_document.md
+++ b/docs/internal/design_docs/connect_design_document.md
@@ -72,13 +72,13 @@ graph TD
 
 ### 3.4. Data Transport Checks (Spark)
 Data transport validation tests that the data processing cluster can fetch data from the source Oracle database.
-* **GCP Dataproc / Dataproc Batches**:
+* **Google Managed Spark / Managed Spark serverless**:
   * Validates availability of the `gcloud` command-line executable.
-  * Checks integration with Google Dataproc (clusters) or Google Dataproc Batches (serverless Spark).
+  * Checks integration with Google Managed Spark (clusters) or Google Managed Spark (serverless).
 * **Generic Spark Submit**: Validates the availability of `spark-submit` executable if configured.
 * **RDBMS Connection Callback (Loopback Ping)**:
   * For the active transport method, `connect` triggers a remote Spark task that attempts to establish a JDBC connection back to the source Oracle Database (`ping_source_rdbms()`).
-  * If the remote job cannot connect back (e.g., due to firewall blockages between the Dataproc network and the Oracle database host), the test reports a **Failure**.
+  * If the remote job cannot connect back (e.g., due to firewall blockages between the Managed Spark network and the Oracle database host), the test reports a **Failure**.
 
 ### 3.5. Local Checks
 * **OS Distribution & Kernel Check**: Reads `/etc/redhat-release`, `/etc/SuSE-release`, or `/etc/os-release` and executes `uname -r`. Fails if the operating system distribution is unrecognized.
@@ -96,7 +96,7 @@ Data transport validation tests that the data processing cluster can fetch data 
 | :--- | :--- | :--- |
 | **`0`** | Success | All executed checks completed successfully. |
 | **`1`** | Fatal | A critical/uncaught exception occurred (e.g., completely unable to connect to Oracle RDBMS during startup). |
-| **`2`** | Failure | One or more active validation checks failed (e.g., Dataproc callback failed, KMS key disabled). |
+| **`2`** | Failure | One or more active validation checks failed (e.g., Managed Spark callback failed, KMS key disabled). |
 | **`3`** | Warning | No failures occurred, but one or more warnings were detected (e.g., incorrect `offload.env` permissions). |
 
 ---

--- a/src/goe/connect/connect_transport.py
+++ b/src/goe/connect/connect_transport.py
@@ -287,7 +287,7 @@ def test_spark_gcloud(orchestration_config, messages):
         log("Skipping Spark gcloud tests due to absent config", detail=VVERBOSE)
         return
 
-    test_name = "Spark Dataproc settings"
+    test_name = "Google Managed Spark settings"
     test_header(test_name)
     if spark_submit_executable_exists(
         orchestration_config,
@@ -309,7 +309,7 @@ def test_spark_gcloud(orchestration_config, messages):
             orchestration_config, messages
         )
         verify_offload_transport_rdbms_connectivity(
-            data_transport_client, "Spark Dataproc"
+            data_transport_client, "Google Managed Spark"
         )
 
     if is_spark_gcloud_batches_available(orchestration_config, None, messages=messages):
@@ -317,7 +317,7 @@ def test_spark_gcloud(orchestration_config, messages):
             orchestration_config, messages
         )
         verify_offload_transport_rdbms_connectivity(
-            data_transport_client, "Spark Dataproc Batches"
+            data_transport_client, "Google Managed Spark serverless"
         )
 
 

--- a/src/goe/offload/factory/offload_transport_factory.py
+++ b/src/goe/offload/factory/offload_transport_factory.py
@@ -195,7 +195,7 @@ def spark_livy_jdbc_connectivity_checker(offload_options, messages):
 
 
 def spark_dataproc_jdbc_connectivity_checker(offload_options, messages):
-    """Connect needs a cut down client to simply check RDBMS connectivity from Dataproc
+    """Connect needs a cut down client to simply check RDBMS connectivity from Managed Spark
     back to the source RDBMS is correctly configured
     """
     from goe.offload.spark.dataproc_offload_transport import (
@@ -207,8 +207,8 @@ def spark_dataproc_jdbc_connectivity_checker(offload_options, messages):
 
 
 def spark_dataproc_batches_jdbc_connectivity_checker(offload_options, messages):
-    """Connect needs a cut down client to simply check RDBMS connectivity from Dataproc Batches
-    back to the source RDBMS is correctly configured
+    """Connect needs a cut down client to simply check RDBMS connectivity from Managed
+    Spark serverless back to the source RDBMS is correctly configured
     """
     from goe.offload.spark.dataproc_offload_transport import (
         OffloadTransportSparkBatchesGcloudCanary,

--- a/src/goe/offload/spark/dataproc_offload_transport.py
+++ b/src/goe/offload/spark/dataproc_offload_transport.py
@@ -51,7 +51,7 @@ GCLOUD_BATCHES_STATE_MESSAGE_TASK_NOT_ACQUIRED = "Task was not acquired"
 
 
 class OffloadTransportSparkBatchesGcloud(OffloadTransportSpark):
-    """Submit PySpark to Dataproc via gcloud to transport data."""
+    """Submit PySpark to Managed Spark via gcloud to transport data."""
 
     def __init__(
         self,
@@ -143,7 +143,7 @@ class OffloadTransportSparkBatchesGcloud(OffloadTransportSpark):
         return gcloud_cmd
 
     def _get_batch_name(self) -> str:
-        """Return a Dataproc Batch name.
+        """Return a Managed Spark serverless name.
 
         Valid names only accept a simple set of characters and are 4-63 characters in length only.
         """
@@ -295,7 +295,7 @@ class OffloadTransportSparkBatchesGcloud(OffloadTransportSpark):
         return rows_imported
 
     def _tune_dataproc_for_parallelism(self) -> list:
-        """Modify Spark Dataproc settings to cater for Offload parallelism.
+        """Modify Managed Spark settings to cater for Offload parallelism.
 
         As of 2024-05-01 the default value for spark.executor.cores is 4 and value values are 4, 8 and 16 only.
         This is specifying cores per executor instance, spark.executor.instances, which defaults to 2.
@@ -328,7 +328,7 @@ class OffloadTransportSparkBatchesGcloud(OffloadTransportSpark):
         ):
             # If the user has not configured spark.executor.cores/instances then
             # increase them from defaults to cater for offload_transport_parallelism.
-            # This only applies to Dataproc Batches and therefore is not injected
+            # This only applies to Managed Spark serverless and therefore is not injected
             # into self._spark_config_properties.
             props = []
             if executor_cores():
@@ -360,7 +360,7 @@ class OffloadTransportSparkBatchesGcloud(OffloadTransportSpark):
             reponse_dict = json.loads(describe_output)
         except Exception as exc:
             # If we can't decode the output then log it and fall back to submit output checking.
-            self.log(f"Exception describing Dataproc batch: {str(exc)}", detail=VERBOSE)
+            self.log(f"Exception describing Managed Spark batch: {str(exc)}", detail=VERBOSE)
             return False
         state = reponse_dict.get("state")
         state_message = reponse_dict.get("stateMessage", "")
@@ -374,12 +374,12 @@ class OffloadTransportSparkBatchesGcloud(OffloadTransportSpark):
                 )
             elif GCLOUD_BATCHES_STATE_MESSAGE_TASK_NOT_ACQUIRED in state_message:
                 raise OffloadTransportException(
-                    f"Dataproc batch failed with stateMessage containing '{GCLOUD_BATCHES_STATE_MESSAGE_TASK_NOT_ACQUIRED}'. "
-                    "The likely cause is missing VPC network/firewall prerequisites for Dataproc Serverless"
+                    f"Managed Spark batch failed with stateMessage containing '{GCLOUD_BATCHES_STATE_MESSAGE_TASK_NOT_ACQUIRED}'. "
+                    "The likely cause is missing VPC network/firewall prerequisites for Managed Spark serverless"
                 )
             else:
                 raise OffloadTransportException(
-                    f"Dataproc batch failed with state: {state}"
+                    f"Managed Spark batch failed with state: {state}"
                 )
 
     def _verify_rdbms_connectivity(self):
@@ -430,7 +430,7 @@ class OffloadTransportSparkBatchesGcloud(OffloadTransportSpark):
 
 
 class OffloadTransportSparkBatchesGcloudCanary(OffloadTransportSparkBatchesGcloud):
-    """Validate Spark Dataproc Serverless connectivity"""
+    """Validate Managed Spark serverless connectivity"""
 
     def __init__(self, offload_options, messages):
         """CONSTRUCTOR
@@ -495,8 +495,8 @@ class OffloadTransportSparkBatchesGcloudCanary(OffloadTransportSparkBatchesGclou
         self._staging_format = None
 
     def _get_batch_name(self) -> str:
-        """Return a Dataproc Batch name for canary check."""
-        # Dataproc batch names only accept a simple set of characters and 4-63 characters in length
+        """Return a Managed Spark serverless batch name for canary check."""
+        # Managed Spark serverless batch names only accept a simple set of characters and 4-63 characters in length
         return self._get_transport_app_name(
             sep="-", ts=True, name_override="canary"
         ).lower()[:64]
@@ -510,7 +510,7 @@ class OffloadTransportSparkBatchesGcloudCanary(OffloadTransportSparkBatchesGclou
 
 
 class OffloadTransportSparkDataprocGcloud(OffloadTransportSparkBatchesGcloud):
-    """Submit PySpark to Dataproc via gcloud to transport data."""
+    """Submit PySpark to Managed Spark via gcloud to transport data."""
 
     def _gcloud_dataproc_submit_command(self, id: str = None) -> list:
         gcloud_cmd = [
@@ -536,16 +536,16 @@ class OffloadTransportSparkDataprocGcloud(OffloadTransportSparkBatchesGcloud):
         return gcloud_cmd
 
     def _tune_dataproc_for_parallelism(self) -> list:
-        # No-op when not Dataproc Batches.
+        # No-op when not Managed Spark serverless.
         return []
 
     def _verify_batch(self, batch_name: str):
-        # No-op when not Dataproc Batches.
+        # No-op when not Managed Spark serverless.
         pass
 
 
 class OffloadTransportSparkDataprocGcloudCanary(OffloadTransportSparkDataprocGcloud):
-    """Validate Dataproc connectivity"""
+    """Validate Managed Spark connectivity"""
 
     def __init__(self, offload_options, messages):
         """CONSTRUCTOR
@@ -606,8 +606,8 @@ class OffloadTransportSparkDataprocGcloudCanary(OffloadTransportSparkDataprocGcl
         self._staging_format = None
 
     def _get_batch_name(self) -> str:
-        """Return a Dataproc Batch name for canary check."""
-        # Dataproc batch names only accept a simple set of characters and 4-63 characters in length
+        """Return a Managed Spark serverless batch name for canary check."""
+        # Managed Spark serverless batch names only accept a simple set of characters and 4-63 characters in length
         return self._get_transport_app_name(
             sep="-", ts=True, name_override="canary"
         ).lower()[:64]

--- a/templates/conf/offload.env.template.bigquery
+++ b/templates/conf/offload.env.template.bigquery
@@ -42,21 +42,21 @@ GOOGLE_KMS_KEY_RING_LOCATION=
 GOOGLE_KMS_KEY_RING_NAME=
 GOOGLE_KMS_KEY_NAME=
 
-# Google Dataproc cluster name
+# Google Managed Spark cluster name
 GOOGLE_DATAPROC_CLUSTER=
-# Google Dataproc/Dataproc Batches project ID
+# Google Managed Spark project ID
 GOOGLE_DATAPROC_PROJECT=
-# Google Dataproc/Dataproc Batches region
+# Google Managed Spark region
 GOOGLE_DATAPROC_REGION=
-# Google Dataproc/Dataproc Batches service account
+# Google Managed Spark service account
 GOOGLE_DATAPROC_SERVICE_ACCOUNT=
-# Google Dataproc Batches version, leave blank to disable Dataproc Batches
+# Google Managed Spark serverless version, leave blank to disable Managed Spark serverless
 GOOGLE_DATAPROC_BATCHES_VERSION=
-# Google Dataproc Batches subnet
+# Google Managed Spark serverless subnet
 # GOOGLE_DATAPROC_BATCHES_SUBNET defines a full subnet URI, for example:
 #   projects/my-project/regions/my-region/subnetworks/my-subnet
 GOOGLE_DATAPROC_BATCHES_SUBNET=
-# Google Dataproc Batches TTL
+# Google Managed Spark serverless TTL
 GOOGLE_DATAPROC_BATCHES_TTL=2d
 
 # Filesystem type for Offloaded tables

--- a/templates/conf/offload.env.template.common
+++ b/templates/conf/offload.env.template.common
@@ -55,7 +55,8 @@ OFFLOAD_TRANSPORT_SPARK_OVERRIDES=
 # Key/value pairs, in JSON format, to override Spark property defaults, e.g.:
 #     OFFLOAD_TRANSPORT_SPARK_PROPERTIES='{"spark.extraListeners": "GOETaskListener", "spark.executor.memory": "4G"}'
 # spark.extraListeners: GOETaskListener is required for Offload Transport verification. Extra listeners may be added to the JSON below.
-OFFLOAD_TRANSPORT_SPARK_PROPERTIES='{"spark.extraListeners": "GOETaskListener", "spark.jars.packages": "com.oracle.database.jdbc:ojdbc11:23.2.0.0,org.apache.spark:spark-avro_2.12:3.3.0"}'
+# spark-avro version: Should match the version of Spark and Scala used by the Spark cluster, or implied by GOOGLE_DATAPROC_BATCHES_VERSION.
+OFFLOAD_TRANSPORT_SPARK_PROPERTIES='{"spark.extraListeners": "GOETaskListener", "spark.jars.packages": "com.oracle.database.jdbc:ojdbc11:23.2.0.0,org.apache.spark:spark-avro_2.12:3.5.1"}'
 # CSV of files to be passed to Spark. Does not apply to Thriftserver or Livy transport methods.
 OFFLOAD_TRANSPORT_SPARK_FILES=
 # CSV of JAR files to be passed to Spark. Does not apply to Thriftserver or Livy transport methods.

--- a/tests/integration/scenarios/test_offload_transport.py
+++ b/tests/integration/scenarios/test_offload_transport.py
@@ -380,11 +380,11 @@ def test_offload_transport_spark_submit(config, schema, data_db):
 
 
 def test_offload_transport_dataproc_cluster(config, schema, data_db):
-    """Test simple offload with Dataproc."""
+    """Test simple offload with Managed Spark."""
     id = "test_offload_transport_dataproc_cluster"
     with get_test_messages_ctx(config, id) as messages:
         if not is_spark_gcloud_dataproc_available(config, None, messages=messages):
-            pytest.skip(f"Skipping {id} because Dataproc is not configured")
+            pytest.skip(f"Skipping {id} because Managed Spark is not configured")
 
         simple_offload_test(
             config,
@@ -398,11 +398,11 @@ def test_offload_transport_dataproc_cluster(config, schema, data_db):
 
 
 def test_offload_transport_dataproc_batches(config, schema, data_db):
-    """Test simple offload with Dataproc."""
+    """Test simple offload with Managed Spark serverless."""
     id = "test_offload_transport_dataproc_batches"
     with get_test_messages_ctx(config, id) as messages:
         if not is_spark_gcloud_batches_available(config, None, messages=messages):
-            pytest.skip(f"Skipping {id} because Dataproc Batches is not configured")
+            pytest.skip(f"Skipping {id} because Managed Spark serverless is not configured")
 
         simple_offload_test(
             config,

--- a/tests/integration/scenarios/test_offload_transport_oracle_iot.py
+++ b/tests/integration/scenarios/test_offload_transport_oracle_iot.py
@@ -335,14 +335,14 @@ def test_offload_transport_oracle_iot_num_qi(
 def test_offload_transport_oracle_iot_num_dataproc_cluster(
     config: OrchestrationConfig, schema: str, data_db: str
 ):
-    """Test IOT offload with Dataproc."""
+    """Test IOT offload with Managed Spark."""
     id = "test_offload_transport_oracle_iot_num_dataproc_cluster"
     if config.db_type != offload_constants.DBTYPE_ORACLE:
         pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
     with get_test_messages_ctx(config, id) as messages:
         if not is_spark_gcloud_dataproc_available(config, None, messages=messages):
-            pytest.skip(f"Skipping {id} because Dataproc is not configured")
+            pytest.skip(f"Skipping {id} because Managed Spark is not configured")
 
         iot_num_dim_tests(
             config,
@@ -359,14 +359,14 @@ def test_offload_transport_oracle_iot_num_dataproc_cluster(
 def test_offload_transport_oracle_iot_num_dataproc_batches(
     config: OrchestrationConfig, schema: str, data_db: str
 ):
-    """Test IOT offload with Dataproc Batches."""
+    """Test IOT offload with Managed Spark Batches."""
     id = "test_offload_transport_oracle_iot_num_dataproc_batches"
     if config.db_type != offload_constants.DBTYPE_ORACLE:
         pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
     with get_test_messages_ctx(config, id) as messages:
         if not is_spark_gcloud_batches_available(config, None, messages=messages):
-            pytest.skip(f"Skipping {id} because Dataproc Batches is not configured")
+            pytest.skip(f"Skipping {id} because Managed Spark serverless is not configured")
 
         iot_num_dim_tests(
             config,
@@ -434,14 +434,14 @@ def test_offload_transport_oracle_iot_num_sqoop(
 def test_offload_transport_oracle_iot_ts_dataproc_cluster(
     config: OrchestrationConfig, schema: str, data_db: str
 ):
-    """Test IOT offload with Dataproc."""
+    """Test IOT offload with Managed Spark."""
     id = "test_offload_transport_oracle_iot_ts_dataproc_cluster"
     if config.db_type != offload_constants.DBTYPE_ORACLE:
         pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
     with get_test_messages_ctx(config, id) as messages:
         if not is_spark_gcloud_dataproc_available(config, None, messages=messages):
-            pytest.skip(f"Skipping {id} because Dataproc is not configured")
+            pytest.skip(f"Skipping {id} because Managed Spark is not configured")
 
         iot_ts_dim_tests(
             config,
@@ -458,14 +458,14 @@ def test_offload_transport_oracle_iot_ts_dataproc_cluster(
 def test_offload_transport_oracle_iot_ts_dataproc_batches(
     config: OrchestrationConfig, schema: str, data_db: str
 ):
-    """Test IOT offload with Dataproc Batches."""
+    """Test IOT offload with Managed Spark serverless."""
     id = "test_offload_transport_oracle_iot_ts_dataproc_batches"
     if config.db_type != offload_constants.DBTYPE_ORACLE:
         pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
     with get_test_messages_ctx(config, id) as messages:
         if not is_spark_gcloud_batches_available(config, None, messages=messages):
-            pytest.skip(f"Skipping {id} because Dataproc Batches is not configured")
+            pytest.skip(f"Skipping {id} because Managed Spark serverless is not configured")
 
         iot_ts_dim_tests(
             config,
@@ -533,14 +533,14 @@ def test_offload_transport_oracle_iot_ts_sqoop(
 def test_offload_transport_oracle_iot_str_dataproc_cluster(
     config: OrchestrationConfig, schema: str, data_db: str
 ):
-    """Test IOT offload with Dataproc."""
+    """Test IOT offload with Managed Spark."""
     id = "test_offload_transport_oracle_iot_str_dataproc_cluster"
     if config.db_type != offload_constants.DBTYPE_ORACLE:
         pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
     with get_test_messages_ctx(config, id) as messages:
         if not is_spark_gcloud_dataproc_available(config, None, messages=messages):
-            pytest.skip(f"Skipping {id} because Dataproc is not configured")
+            pytest.skip(f"Skipping {id} because Managed Spark is not configured")
 
         iot_str_dim_tests(
             config,
@@ -557,14 +557,14 @@ def test_offload_transport_oracle_iot_str_dataproc_cluster(
 def test_offload_transport_oracle_iot_str_dataproc_batches(
     config: OrchestrationConfig, schema: str, data_db: str
 ):
-    """Test IOT offload with Dataproc Batches."""
+    """Test IOT offload with Managed Spark serverless."""
     id = "test_offload_transport_oracle_iot_str_dataproc_batches"
     if config.db_type != offload_constants.DBTYPE_ORACLE:
         pytest.skip(f"Skipping {id} for frontend: {config.db_type}")
 
     with get_test_messages_ctx(config, id) as messages:
         if not is_spark_gcloud_batches_available(config, None, messages=messages):
-            pytest.skip(f"Skipping {id} because Dataproc Batches is not configured")
+            pytest.skip(f"Skipping {id} because Managed Spark serverless is not configured")
 
         iot_str_dim_tests(
             config,

--- a/tests/unit/offload/test_offload_transport.py
+++ b/tests/unit/offload/test_offload_transport.py
@@ -183,7 +183,7 @@ def test_dataproc_cmd(config, messages, oracle_table, fake_operation):
     assert (
         f"--region={config.google_dataproc_region}" in cmd
     ), f"region option is missing from cmd: {cmd}"
-    # batch option should NOT be in standard Dataproc job commands.
+    # batch option should NOT be in standard Managed Spark job commands.
     assert all(
         "--batch=" not in _ for _ in cmd
     ), f"batch option is incorrectly in cmd: {cmd}"

--- a/tools/spark-listener/Makefile
+++ b/tools/spark-listener/Makefile
@@ -12,41 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-JAR_FOR_SPARK_330=spark-3.3.0-listener_2.12-1.0.jar
-JAR_FOR_SPARK_320=spark-3.2.0-listener_2.12-1.0.jar
-JAR_FOR_SPARK_312=spark-3.1.2-listener_2.12-1.0.jar
 JAR_FOR_SPARK_301=spark-3.0.1-listener_2.12-1.0.jar
-TARGET_JAR_FOR_SPARK_330=target/scala-2.12/$(JAR_FOR_SPARK_330)
-TARGET_JAR_FOR_SPARK_320=target/scala-2.12/$(JAR_FOR_SPARK_320)
-TARGET_JAR_FOR_SPARK_312=target/scala-2.12/$(JAR_FOR_SPARK_312)
+JAR_FOR_SPARK_312=spark-3.1.2-listener_2.12-1.0.jar
+JAR_FOR_SPARK_320=spark-3.2.0-listener_2.12-1.0.jar
+JAR_FOR_SPARK_330=spark-3.3.0-listener_2.12-1.0.jar
+JAR_FOR_SPARK_351_212=spark-3.5.1-listener_2.12-1.0.jar
+JAR_FOR_SPARK_351_213=spark-3.5.1-listener_2.13-1.0.jar
+JAR_FOR_SPARK_353_213=spark-3.5.3-listener_2.13-1.0.jar
 TARGET_JAR_FOR_SPARK_301=target/scala-2.12/$(JAR_FOR_SPARK_301)
+TARGET_JAR_FOR_SPARK_312=target/scala-2.12/$(JAR_FOR_SPARK_312)
+TARGET_JAR_FOR_SPARK_320=target/scala-2.12/$(JAR_FOR_SPARK_320)
+TARGET_JAR_FOR_SPARK_330=target/scala-2.12/$(JAR_FOR_SPARK_330)
+TARGET_JAR_FOR_SPARK_351_212=target/scala-2.12/$(JAR_FOR_SPARK_351_212)
+TARGET_JAR_FOR_SPARK_351_213=target/scala-2.13/$(JAR_FOR_SPARK_351_213)
+TARGET_JAR_FOR_SPARK_353_213=target/scala-2.13/$(JAR_FOR_SPARK_353_213)
 INSTALL_DIR=../../target/offload/lib
 INSTALL_JAR=$(INSTALL_DIR)/goe-spark-listener.jar
 
 all: spark-listener
 
 .PHONY: spark-listener
-spark-listener: $(TARGET_JAR_FOR_SPARK_330) $(TARGET_JAR_FOR_SPARK_320) $(TARGET_JAR_FOR_SPARK_312) $(TARGET_JAR_FOR_SPARK_301)
-
-$(TARGET_JAR_FOR_SPARK_330):
-	sbt -DsparkVersion=3.3.0 "reload; package"
-
-$(TARGET_JAR_FOR_SPARK_320):
-	sbt -DsparkVersion=3.2.0 "reload; package"
-
-$(TARGET_JAR_FOR_SPARK_312):
-	sbt -DsparkVersion=3.1.2 "reload; package"
+spark-listener: $(TARGET_JAR_FOR_SPARK_330) $(TARGET_JAR_FOR_SPARK_320) $(TARGET_JAR_FOR_SPARK_312) $(TARGET_JAR_FOR_SPARK_301) $(TARGET_JAR_FOR_SPARK_351_212) $(TARGET_JAR_FOR_SPARK_351_213) $(TARGET_JAR_FOR_SPARK_353_213)
 
 $(TARGET_JAR_FOR_SPARK_301):
 	sbt -DsparkVersion=3.0.1 "reload; package"
 
+$(TARGET_JAR_FOR_SPARK_312):
+	sbt -DsparkVersion=3.1.2 "reload; package"
+
+$(TARGET_JAR_FOR_SPARK_320):
+	sbt -DsparkVersion=3.2.0 "reload; package"
+
+$(TARGET_JAR_FOR_SPARK_330):
+	sbt -DsparkVersion=3.3.0 "reload; package"
+
+$(TARGET_JAR_FOR_SPARK_351_212):
+	sbt -DsparkVersion=3.5.1 -DscalaVersion=2.12.18 "reload; package"
+
+$(TARGET_JAR_FOR_SPARK_351_213):
+	sbt -DsparkVersion=3.5.1 -DscalaVersion=2.13.11 "reload; package"
+
+$(TARGET_JAR_FOR_SPARK_353_213):
+	sbt -DsparkVersion=3.5.3 -DscalaVersion=2.13.11 "reload; package"
+
 target: $(INSTALL_DIR) spark-listener
-	cp $(TARGET_JAR_FOR_SPARK_330) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_330)
-	cp $(TARGET_JAR_FOR_SPARK_320) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_320)
-	cp $(TARGET_JAR_FOR_SPARK_312) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_312)
 	cp $(TARGET_JAR_FOR_SPARK_301) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_301)
-	# Default to Spark 3.2.0 compatible Spark Listener because that is the current bundled version.
-	cp $(TARGET_JAR_FOR_SPARK_320) $(INSTALL_JAR)
+	cp $(TARGET_JAR_FOR_SPARK_312) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_312)
+	cp $(TARGET_JAR_FOR_SPARK_320) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_320)
+	cp $(TARGET_JAR_FOR_SPARK_330) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_330)
+	cp $(TARGET_JAR_FOR_SPARK_351_212) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_351_212)
+	cp $(TARGET_JAR_FOR_SPARK_351_213) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_351_213)
+	cp $(TARGET_JAR_FOR_SPARK_353_213) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_353_213)
+	# Default to Spark 3.5.1 2.12 compatible Spark Listener because that is the
+	# current Google Managed Spark serverless default.
+	cp $(TARGET_JAR_FOR_SPARK_351_212) $(INSTALL_JAR)
 
 $(INSTALL_DIR):
 	mkdir -p $(INSTALL_DIR)
@@ -54,5 +73,5 @@ $(INSTALL_DIR):
 .PHONY: clean
 clean:
 	sbt clean
-	rm -f $(TARGET_JAR_FOR_SPARK_330) $(TARGET_JAR_FOR_SPARK_320) $(TARGET_JAR_FOR_SPARK_312) $(TARGET_JAR_FOR_SPARK_301)
-	rm -f $(INSTALL_JAR) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_330) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_320) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_312) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_301)
+	rm -f $(TARGET_JAR_FOR_SPARK_330) $(TARGET_JAR_FOR_SPARK_320) $(TARGET_JAR_FOR_SPARK_312) $(TARGET_JAR_FOR_SPARK_301) $(TARGET_JAR_FOR_SPARK_351_212) $(TARGET_JAR_FOR_SPARK_351_213) $(TARGET_JAR_FOR_SPARK_353_213)
+	rm -f $(INSTALL_JAR) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_330) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_320) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_312) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_301) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_351_212) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_351_213) $(INSTALL_DIR)/goe-$(JAR_FOR_SPARK_353_213)

--- a/tools/spark-listener/build.sbt
+++ b/tools/spark-listener/build.sbt
@@ -15,7 +15,7 @@
 */
 
 ThisBuild / organization := "com.goe"
-ThisBuild / scalaVersion := "2.12.14"
+ThisBuild / scalaVersion := sys.props.getOrElse("scalaVersion", "2.12.18")
 ThisBuild / version      := "1.0"
 
 val sparkVersion = sys.props.getOrElse("sparkVersion", "3.2.0")


### PR DESCRIPTION
This PR:

1. Updates Spark dependencies for GOE Spark Listener
2. Adds some docs for the above updates
3. Rebrands Dataproc to Managed Spark in documentation and messages. We do not rename variables, functions or offload.env items.